### PR TITLE
Fixing get_transactions() call using old session syntax

### DIFF
--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -17,11 +17,15 @@ try:
 except ImportError:
     pd = None
 
-DATE_FIELDS = [
+ACCOUNT_DATE_TIMESTAMP_FIELDS = [
     'addAccountDate',
     'closeDate',
     'fiLastUpdated',
     'lastUpdated',
+]
+
+ACCOUNT_DATE_STRING_FIELDS = [
+    'dueDate'
 ]
 
 class MintHTTPSAdapter(HTTPAdapter):
@@ -118,7 +122,7 @@ class Mint(requests.Session):
 
         # Return datetime objects for dates
         for account in accounts:
-            for df in DATE_FIELDS:
+            for df in ACCOUNT_DATE_TIMESTAMP_FIELDS:
                 if df in account:
                     # Convert from javascript timestamp to unix timestamp
                     # http://stackoverflow.com/a/9744811/5026
@@ -128,6 +132,12 @@ class Mint(requests.Session):
                         # returned data is not a number, don't parse
                         continue
                     account[df + 'InDate'] = datetime.datetime.fromtimestamp(ts)
+            for df in ACCOUNT_DATE_STRING_FIELDS:
+                if df in account.keys():
+                    try:
+                        account["%sInDate" % df] = date_parse(account[df])
+                    except:
+                        continue
         if(get_detail):
             accounts = self.populate_extended_account_detail(accounts)
         return accounts

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -134,9 +134,9 @@ class Mint(requests.Session):
         if not pd:
             raise ImportError('transactions data requires pandas')
         from StringIO import StringIO
-        result = self.session.get(
+        result = self.get(
             'https://wwws.mint.com/transactionDownload.event',
-            headers=self.headers
+            headers=self.json_headers
             )
         if result.status_code != 200:
             raise ValueError(result.status_code)
@@ -160,7 +160,7 @@ class Mint(requests.Session):
             headers['Referer'] = 'https://wwws.mint.com/transaction.event?accountId=' + str(account['id'])
             response = json.loads(self.get(
                 'https://wwws.mint.com/listTransaction.xevent?accountId=' + str(account['id']) + '&queryNew=&offset=0&comparableType=8&acctChanged=T&rnd=' + Mint.get_rnd(),
-                headers = headers
+                headers=headers
             ).text)
             xml = '<div>' + response['accountHeader'] + '</div>'
             xml = xml.replace('&#8211;', '-')

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -209,7 +209,7 @@ class Mint(requests.Session):
             for k in self.TRANSACTION_DATE_FIELDS:
                 if k in transaction.keys():
                     try:
-                        transaction[k] = date_parse(transaction[k])
+                        transaction["%sInDate" % k] = date_parse(transaction[k])
                     except:
                         continue
 

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -7,6 +7,7 @@ import time
 import xmltodict
 import keyring
 
+from dateutil.parser import parse as date_parse
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.poolmanager import PoolManager
 import re
@@ -181,11 +182,10 @@ class Mint(requests.Session):
 
         return transactions, full_page
 
-    def get_transactions(self, detailed=False, account_id=0, page_size=100):
+    TRANSACTION_DATE_FIELDS = ['date', 'odate', ]
+    def get_transactions(self, detailed=True, account_id=0, page_size=100):
         """
         Gets detailed transaction information from Mint. If detailed is True, it gets them in batches of the page size
-        :param account_id:
-        :return:
         """
         self.__update_mint_preference('transactionResults', page_size)
 
@@ -204,6 +204,14 @@ class Mint(requests.Session):
                 transactions += page_transactions
             if not full_page:
                 should_continue = False
+
+        for transaction in transactions:
+            for k in self.TRANSACTION_DATE_FIELDS:
+                if k in transaction.keys():
+                    try:
+                        transaction[k] = date_parse(transaction[k])
+                    except:
+                        continue
 
         return transactions
 

--- a/setup.py
+++ b/setup.py
@@ -26,4 +26,5 @@ setup(
             'mintapi = mintapi.api:main',
         ],
     ),
+    requires=['dateutil==2.4.0']
 )

--- a/setup.py
+++ b/setup.py
@@ -20,11 +20,10 @@ setup(
     author='Michael Rooney',
     author_email='mrooney.mintapi@rowk.com',
     url='https://github.com/mrooney/mintapi',
-    install_requires=['requests', 'xmltodict', 'keyring'],
+    install_requires=['requests', 'xmltodict', 'keyring', 'dateutil',],
     entry_points=dict(
         console_scripts=[
             'mintapi = mintapi.api:main',
         ],
     ),
-    requires=['dateutil==2.4.0']
 )

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     author='Michael Rooney',
     author_email='mrooney.mintapi@rowk.com',
     url='https://github.com/mrooney/mintapi',
-    install_requires=['requests', 'xmltodict', 'keyring', 'dateutil',],
+    install_requires=['requests', 'xmltodict', 'keyring', 'python-dateutil',],
     entry_points=dict(
         console_scripts=[
             'mintapi = mintapi.api:main',


### PR DESCRIPTION
The get_transactions() call was using the self.session.get(...) syntax, but this doesn't work now that the class inherits from requests.Session.

Fixed and tested locally, but didn't write tests, only because test coverage is fairly low on this project anyway.