### PR TITLE
Modified usage of `keyring` to avoid an exception on platforms that don't support the keyring library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,20 +20,20 @@ make calls to retrieve account/budget information.  We recommend using the
 
     import mintapi
     mint = mintapi.Mint(email, password)
-    
+
     # Get basic account information
     mint.get_accounts()
-    
+
     # Get extended account detail at the expense of speed - requires an
     # additional API call for each account
     mint.get_accounts(True)
-    
+
     # Get budget information
     mint.get_budgets()
 
     # Get transactions
     mint.get_transactions()
-    
+
     # Initiate an account refresh
     mint.initiate_account_refresh()
 
@@ -50,28 +50,33 @@ from anywhere
 ---
 Run it as a sub-process from your favorite language; `pip install mintapi` creates a binary in your $PATH. From the command-line, the output is JSON:
 
-    Usage: mintapi [options]
+    usage: mintapi [-h] [--accounts] [--budgets] [--extended-accounts]
+                   [--transactions] [--filename FILENAME] [--keyring]
+                   [email] [password]
 
-    Options:
+    positional arguments:
+      email                 The e-mail address for your Mint.com account
+      password              The password for your Mint.com account
+
+    optional arguments:
       -h, --help            show this help message and exit
       --accounts            Retrieve account information (default if nothing else
                             is specified)
       --budgets             Retrieve budget information
       --extended-accounts   Retrieve extended account information (slower, implies
                             --accounts)
-      -t, --transactions    Retrieve transactions
-      -f FILENAME, --filename=FILENAME
+      --transactions, -t    Retrieve transactions
+      --filename FILENAME, -f FILENAME
                             write results to file. can be {csv,json} format.
                             default is to write to stdout.
-      -u USER, --user=USER  mint email login. uses OS keyring to store password
-                            info.
-    
-    >>> mintapi -u email@example.com
+      --keyring             Use OS keyring for storing password information
+
+    >>> mintapi --keyring email@example.com
     [
       {
-        "accountName": "Chase Checking", 
-        "lastUpdatedInString": "25 minutes", 
-        "accountType": "bank", 
+        "accountName": "Chase Checking",
+        "lastUpdatedInString": "25 minutes",
+        "accountType": "bank",
         "currentBalance": 100.12,
         ...
       },

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -365,30 +365,34 @@ def main():
 
     options = cmdline.parse_args()
 
-    # Handle Python 3's raw_input change.
+    if options.keyring and not keyring:
+        cmdline.error('--keyring can only be used if the `keyring`'
+                      'library is installed.')
+
     try:
-        input = raw_input
+        from __builtin__ import raw_input as input
     except NameError:
         pass
 
+    # Try to get the e-mail and password from the arguments
     email = options.email
     password = options.password
 
     if not email:
+        # If the user did not provide an e-mail, prompt for it
         email = input("Mint e-mail: ")
 
-    if options.keyring:
-        if not keyring:
-            cmdline.error('--keyring can only be used if the `keyring`'
-                          'library is installed.')
-
-        if not password:
-            password = keyring.get_password('mintapi', email)
+    if keyring and not password:
+        # If the keyring module is installed and we don't yet have
+        # a password, try prompting for it
+        password = keyring.get_password('mintapi', email)
 
     if not password:
+        # If we still don't have a password, prompt for it
         password = getpass.getpass("Mint password: ")
 
     if options.keyring:
+        # If keyring option is specified, save the password in the keyring
         keyring.set_password('mintapi', email, password)
 
     if options.accounts_ext:

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -1,12 +1,15 @@
-import datetime
 import json
 import random
-import requests
 import time
-import xmltodict
+
+from datetime import date, datetime, timedelta
+
+import requests
 
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.poolmanager import PoolManager
+
+import xmltodict
 
 try:
     import pandas as pd
@@ -46,7 +49,7 @@ class Mint(requests.Session):
 
     @classmethod
     def get_rnd(cls):  # {{{
-        return (str(int(time.mktime(datetime.datetime.now().timetuple())))
+        return (str(int(time.mktime(datetime.now().timetuple())))
                 + str(random.randrange(999)).zfill(3))
 
     @classmethod
@@ -136,7 +139,7 @@ class Mint(requests.Session):
                     except TypeError:
                         # returned data is not a number, don't parse
                         continue
-                    account[df + 'InDate'] = datetime.datetime.fromtimestamp(ts)
+                    account[df + 'InDate'] = datetime.fromtimestamp(ts)
         if get_detail:
             accounts = self.populate_extended_account_detail(accounts)
         return accounts
@@ -261,9 +264,9 @@ class Mint(requests.Session):
         categories = self.get_categories()
 
         # Issue request for budget utilization
-        today = datetime.date.today()
-        this_month = datetime.date(today.year, today.month, 1)
-        last_year = this_month - datetime.timedelta(days=330)
+        today = date.today()
+        this_month = date(today.year, today.month, 1)
+        last_year = this_month - timedelta(days=330)
         this_month = (str(this_month.month).zfill(2) +
                       '/01/' + str(this_month.year))
         last_year = (str(last_year.month).zfill(2) +
@@ -291,14 +294,13 @@ class Mint(requests.Session):
 
         return budgets
 
-    def initiate_account_refresh(self):  # {{{
+    def initiate_account_refresh(self):
         # Submit refresh request.
         data = {
             'token': self.token
         }
-        response = self.post('https://wwws.mint.com/refreshFILogins.xevent',
-                             data=data, headers=self.json_headers)
-    # }}}
+        self.post('https://wwws.mint.com/refreshFILogins.xevent',
+                  data=data, headers=self.json_headers)
 
 
 def get_accounts(email, password, get_detail=False):
@@ -309,7 +311,7 @@ def get_accounts(email, password, get_detail=False):
 def make_accounts_presentable(accounts):
     for account in accounts:
         for k, v in account.items():
-            if isinstance(v, datetime.datetime):
+            if isinstance(v, datetime):
                 account[k] = repr(v)
     return accounts
 
@@ -331,7 +333,6 @@ def initiate_account_refresh(email, password):
 def main():
     import getpass
     import argparse
-    import sys
 
     try:
         import keyring

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     author='Michael Rooney',
     author_email='mrooney.mintapi@rowk.com',
     url='https://github.com/mrooney/mintapi',
-    install_requires=['requests', 'xmltodict', 'keyring'],
+    install_requires=['requests', 'xmltodict'],
     entry_points=dict(
         console_scripts=[
             'mintapi = mintapi.api:main',


### PR DESCRIPTION
Fixes #35

Also:

- Removed `keyring` from requirements since it now handles the missing library gracefully
- Changed from using the older `optparse` to the newer `argparse` library
- Replaced `--user` flag with `--keyring` and better optional positional username and password argumetns
- Updated the README