### PR TITLE
Reformatted code to follow standard PEP8 conventions

### DIFF
--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -2,7 +2,6 @@ import datetime
 import json
 import random
 import requests
-import ssl
 import time
 import xmltodict
 import keyring
@@ -22,13 +21,16 @@ DATE_FIELDS = [
     'lastUpdated',
 ]
 
+
 class MintHTTPSAdapter(HTTPAdapter):
     def init_poolmanager(self, connections, maxsize, **kwargs):
-        self.poolmanager = PoolManager(num_pools=connections, maxsize=maxsize, **kwargs)
+        self.poolmanager = PoolManager(num_pools=connections,
+                                       maxsize=maxsize, **kwargs)
+
 
 class Mint(requests.Session):
-    json_headers = {"accept": "application/json"}
-    request_id = 42 # magic number? random number?
+    json_headers = {'accept': 'application/json'}
+    request_id = 42  # magic number? random number?
     token = None
 
     def __init__(self, email=None, password=None):
@@ -38,17 +40,18 @@ class Mint(requests.Session):
             self.login_and_get_token(email, password)
 
     @classmethod
-    def create(_, email, password): # {{{
+    def create(cls, email, password):  # {{{
         mint = Mint()
         mint.login_and_get_token(email, password)
         return mint
 
     @classmethod
-    def get_rnd(_): # {{{
-        return str(int(time.mktime(datetime.datetime.now().timetuple()))) + str(random.randrange(999)).zfill(3)
+    def get_rnd(cls):  # {{{
+        return (str(int(time.mktime(datetime.datetime.now().timetuple())))
+                + str(random.randrange(999)).zfill(3))
 
     @classmethod
-    def parse_float(_, string): # {{{
+    def parse_float(cls, string):  # {{{
         for bad_char in ['$', ',', '%']:
             string = string.replace(bad_char, '')
 
@@ -57,62 +60,71 @@ class Mint(requests.Session):
         except ValueError:
             return None
 
-    def login_and_get_token(self, email, password): # {{{
+    def login_and_get_token(self, email, password):  # {{{
         # 0: Check to see if we're already logged in.
-        if(self.token != None):
+        if self.token is not None:
             return
 
         # 1: Login.
-        if self.get("https://wwws.mint.com/login.event?task=L").status_code != requests.codes.ok:
-            raise Exception("Failed to load Mint login page")
+        login_url = 'https://wwws.mint.com/login.event?task=L'
+        if self.get(login_url).status_code != requests.codes.ok:
+            raise Exception('Failed to load Mint login page')
 
-        data = {'username' : email}
-        response = self.post('https://wwws.mint.com/getUserPod.xevent', data = data, headers = self.json_headers).text
+        data = {'username': email}
+        response = self.post('https://wwws.mint.com/getUserPod.xevent',
+                             data=data, headers=self.json_headers).text
 
-        data = {"username": email, "password": password, "task": "L", "browser": "firefox", "browserVersion": "27", "os": "linux"}
-        response = self.post("https://wwws.mint.com/loginUserSubmit.xevent", data=data, headers=self.json_headers).text
+        data = {'username': email, 'password': password, 'task': 'L',
+                'browser': 'firefox', 'browserVersion': '27', 'os': 'linux'}
+        response = self.post('https://wwws.mint.com/loginUserSubmit.xevent',
+                             data=data, headers=self.json_headers).text
 
-        if "token" not in response:
-            raise Exception("Mint.com login failed[1]")
+        if 'token' not in response:
+            raise Exception('Mint.com login failed[1]')
 
         response = json.loads(response)
-        if not response["sUser"]["token"]:
-            raise Exception("Mint.com login failed[2]")
+        if not response['sUser']['token']:
+            raise Exception('Mint.com login failed[2]')
 
         # 2: Grab token.
-        self.token = response["sUser"]["token"]
+        self.token = response['sUser']['token']
 
-    def get_accounts(self, get_detail = False): # {{{
+    def get_accounts(self, get_detail=False):  # {{{
         # Issue service request.
         req_id = str(self.request_id)
-        data = {"input": json.dumps([
-            {"args": {
-                "types": [
-                    "BANK",
-                    "CREDIT",
-                    "INVESTMENT",
-                    "LOAN",
-                    "MORTGAGE",
-                    "OTHER_PROPERTY",
-                    "REAL_ESTATE",
-                    "VEHICLE",
-                    "UNCLASSIFIED"
+
+        input = {
+            'args': {
+                'types': [
+                    'BANK',
+                    'CREDIT',
+                    'INVESTMENT',
+                    'LOAN',
+                    'MORTGAGE',
+                    'OTHER_PROPERTY',
+                    'REAL_ESTATE',
+                    'VEHICLE',
+                    'UNCLASSIFIED'
                 ]
             },
-            "id": req_id,
-            "service": "MintAccountService",
-            "task": "getAccountsSorted"
-            #"task": "getAccountsSortedByBalanceDescending"
-            }
-        ])}
-        response = self.post("https://wwws.mint.com/bundledServiceController.xevent?legacy=false&token="+self.token, data=data, headers=self.json_headers).text
+            'id': req_id,
+            'service': 'MintAccountService',
+            'task': 'getAccountsSorted'
+            # 'task': 'getAccountsSortedByBalanceDescending'
+        }
+
+        data = {'input': json.dumps([input])}
+        account_data_url = ('https://wwws.mint.com/bundledServiceController.'
+                            'xevent?legacy=false&token=' + self.token)
+        response = self.post(account_data_url, data=data,
+                             headers=self.json_headers).text
         self.request_id = self.request_id + 1
         if req_id not in response:
-            raise Exception("Could not parse account data: " + response)
+            raise Exception('Could not parse account data: ' + response)
 
         # Parse the request
         response = json.loads(response)
-        accounts = response["response"][req_id]["response"]
+        accounts = response['response'][req_id]['response']
 
         # Return datetime objects for dates
         for account in accounts:
@@ -126,7 +138,7 @@ class Mint(requests.Session):
                         # returned data is not a number, don't parse
                         continue
                     account[df + 'InDate'] = datetime.datetime.fromtimestamp(ts)
-        if(get_detail):
+        if get_detail:
             accounts = self.populate_extended_account_detail(accounts)
         return accounts
 
@@ -148,20 +160,25 @@ class Mint(requests.Session):
         s.seek(0)
         df = pd.read_csv(s, parse_dates=['Date'])
         df.columns = [c.lower().replace(' ', '_') for c in df.columns]
-        df.category = df.category.str.lower().replace('uncategorized', pd.np.nan)
+        df.category = (df.category.str.lower()
+                       .replace('uncategorized', pd.np.nan))
         return df
 
-    def populate_extended_account_detail(self, accounts): # {{{
+    def populate_extended_account_detail(self, accounts):  # {{{
         # I can't find any way to retrieve this information other than by
         # doing this stupid one-call-per-account to listTransactions.xevent
         # and parsing the HTML snippet :(
         for account in accounts:
             headers = self.json_headers
-            headers['Referer'] = 'https://wwws.mint.com/transaction.event?accountId=' + str(account['id'])
-            response = json.loads(self.get(
-                'https://wwws.mint.com/listTransaction.xevent?accountId=' + str(account['id']) + '&queryNew=&offset=0&comparableType=8&acctChanged=T&rnd=' + Mint.get_rnd(),
-                headers = headers
-            ).text)
+            headers['Referer'] = ('https://wwws.mint.com/transaction.event?'
+                                  'accountId=' + str(account['id']))
+
+            list_txn_url = ('https://wwws.mint.com/listTransaction.xevent?'
+                            'accountId=' + str(account['id']) + '&queryNew=&'
+                            'offset=0&comparableType=8&acctChanged=T&rnd=' +
+                            Mint.get_rnd())
+
+            response = json.loads(self.get(list_txn_url, headers=headers).text)
             xml = '<div>' + response['accountHeader'] + '</div>'
             xml = xml.replace('&#8211;', '-')
             xml = xmltodict.parse(xml)
@@ -173,81 +190,99 @@ class Mint(requests.Session):
             account['nextPaymentDate'] = None
 
             xml = xml['div']['div'][1]['table']
-            if(not 'tbody' in xml):
+            if 'tbody' not in xml:
                 continue
             xml = xml['tbody']
             table_type = xml['@id']
             xml = xml['tr'][1]['td']
 
-            if(table_type == 'account-table-bank'):
+            if table_type == 'account-table-bank':
                 account['availableMoney'] = Mint.parse_float(xml[1]['#text'])
                 account['totalFees'] = Mint.parse_float(xml[3]['a']['#text'])
-                if(account['interestRate'] == None):
-                    account['interestRate'] = Mint.parse_float(xml[2]['#text']) / 100.0
-            elif(table_type == 'account-table-credit'):
+                if (account['interestRate'] is None):
+                    account['interestRate'] = (
+                        Mint.parse_float(xml[2]['#text']) / 100.0
+                    )
+            elif table_type == 'account-table-credit':
                 account['availableMoney'] = Mint.parse_float(xml[1]['#text'])
                 account['totalCredit'] = Mint.parse_float(xml[2]['#text'])
                 account['totalFees'] = Mint.parse_float(xml[4]['a']['#text'])
-                if(account['interestRate'] == None):
-                    account['interestRate'] = Mint.parse_float(xml[3]['#text']) / 100.0
-            elif(table_type == 'account-table-loan'):
-                account['nextPaymentAmount'] = Mint.parse_float(xml[1]['#text'])
+                if account['interestRate'] is None:
+                    account['interestRate'] = (
+                        Mint.parse_float(xml[3]['#text']) / 100.0
+                    )
+            elif table_type == 'account-table-loan':
+                account['nextPaymentAmount'] = (
+                    Mint.parse_float(xml[1]['#text'])
+                )
                 account['nextPaymentDate'] = xml[2].get('#text', None)
-            elif(table_type == 'account-type-investment'):
+            elif table_type == 'account-type-investment':
                 account['totalFees'] = Mint.parse_float(xml[2]['a']['#text'])
 
         return accounts
 
-    def get_categories(self): # {{{
+    def get_categories(self):  # {{{
         # Get category metadata.
         req_id = str(self.request_id)
         data = {
             'input': json.dumps([{
                 'args': {
-                    'excludedCategories' : [],
-                    'sortByPrecedence' : False,
-                    'categoryTypeFilter' : 'FREE'
+                    'excludedCategories': [],
+                    'sortByPrecedence': False,
+                    'categoryTypeFilter': 'FREE'
                 },
                 'id': req_id,
                 'service': 'MintCategoryService',
                 'task': 'getCategoryTreeDto2'
             }])
         }
-        response = self.post('https://wwws.mint.com/bundledServiceController.xevent?legacy=false&token=' + self.token, data = data, headers = self.json_headers).text
+
+        cat_url = ('https://wwws.mint.com/bundledServiceController.xevent'
+                   '?legacy=false&token=' + self.token)
+        response = self.post(cat_url, data=data,
+                             headers=self.json_headers).text
         self.request_id = self.request_id + 1
-        if(req_id not in response):
-            raise Exception('Could not parse category data: "' + response + '"')
+        if req_id not in response:
+            raise Exception('Could not parse category data: "'
+                            + response + '"')
         response = json.loads(response)
         response = response['response'][req_id]['response']
 
         # Build category list
         categories = {}
         for category in response['allCategories']:
-            if(category['parentId'] == 0):
+            if category['parentId'] == 0:
                 continue
             categories[category['id']] = category
 
         return categories
 
-    def get_budgets(self): # {{{
+    def get_budgets(self):  # {{{
         # Get categories
         categories = self.get_categories()
 
         # Issue request for budget utilization
         today = datetime.date.today()
         this_month = datetime.date(today.year, today.month, 1)
-        last_year = this_month - datetime.timedelta(days = 330)
-        this_month = str(this_month.month).zfill(2) + '/01/' + str(this_month.year)
-        last_year = str(last_year.month).zfill(2) + '/01/' + str(last_year.year)
+        last_year = this_month - datetime.timedelta(days=330)
+        this_month = (str(this_month.month).zfill(2) +
+                      '/01/' + str(this_month.year))
+        last_year = (str(last_year.month).zfill(2) +
+                     '/01/' + str(last_year.year))
         response = json.loads(self.get(
-            'https://wwws.mint.com/getBudget.xevent?startDate=' + last_year + '&endDate=' + this_month + '&rnd=' + Mint.get_rnd(),
-            headers = self.json_headers
+            'https://wwws.mint.com/getBudget.xevent?startDate=' + last_year +
+            '&endDate=' + this_month + '&rnd=' + Mint.get_rnd(),
+            headers=self.json_headers
         ).text)
 
         # Make the skeleton return structure
         budgets = {
-            'income' : response['data']['income'][str(max(map(int, response['data']['income'].keys())))]['bu'],
-            'spend' : response['data']['spending'][str(max(map(int, response['data']['income'].keys())))]['bu']
+            'income': response['data']['income'][
+                str(max(map(int, response['data']['income'].keys())))
+            ]['bu'],
+            'spend': response['data']['spending'][
+                str(max(map(int, response['data']['income'].keys())))
+            ]['bu']
         }
 
         # Fill in the return structure
@@ -257,17 +292,20 @@ class Mint(requests.Session):
 
         return budgets
 
-    def initiate_account_refresh(self): # {{{
+    def initiate_account_refresh(self):  # {{{
         # Submit refresh request.
         data = {
-            'token' : self.token
+            'token': self.token
         }
-        response = self.post('https://wwws.mint.com/refreshFILogins.xevent', data = data, headers = self.json_headers)
+        response = self.post('https://wwws.mint.com/refreshFILogins.xevent',
+                             data=data, headers=self.json_headers)
     # }}}
 
-def get_accounts(email, password, get_detail = False):
+
+def get_accounts(email, password, get_detail=False):
     mint = Mint.create(email, password)
-    return mint.get_accounts(get_detail = get_detail)
+    return mint.get_accounts(get_detail=get_detail)
+
 
 def make_accounts_presentable(accounts):
     for account in accounts:
@@ -276,16 +314,20 @@ def make_accounts_presentable(accounts):
                 account[k] = repr(v)
     return accounts
 
+
 def print_accounts(accounts):
-    print(json.dumps(make_accounts_presentable(accounts), indent = 2))
+    print(json.dumps(make_accounts_presentable(accounts), indent=2))
+
 
 def get_budgets(email, password):
     mint = Mint.create(email, password)
     return mint.get_budgets()
 
+
 def initiate_account_refresh(email, password):
     mint = Mint.create(email, password)
     return mint.initiate_account_refresh()
+
 
 def main():
     import getpass
@@ -322,18 +364,20 @@ def main():
         email = input("Mint email: ")
         password = getpass.getpass("Password: ")
 
-    if(options.accounts_ext):
+    if options.accounts_ext:
         options.accounts = True
 
-    if(not (options.accounts or options.budgets or options.transactions)):
+    if not (options.accounts or options.budgets or options.transactions):
         options.accounts = True
 
     mint = Mint.create(email, password)
 
     data = None
-    if(options.accounts and options.budgets):
+    if options.accounts and options.budgets:
         try:
-            accounts = make_accounts_presentable(mint.get_accounts(get_detail = options.accounts_ext))
+            accounts = make_accounts_presentable(
+                mint.get_accounts(get_detail=options.accounts_ext)
+            )
         except:
             accounts = None
 
@@ -342,15 +386,17 @@ def main():
         except:
             budgets = None
 
-        data = {'accounts' : accounts, 'budgets' : budgets}
-    elif(options.budgets):
+        data = {'accounts': accounts, 'budgets': budgets}
+    elif options.budgets:
         try:
             data = mint.get_budgets()
         except:
             data = None
-    elif(options.accounts):
+    elif options.accounts:
         try:
-            data = make_accounts_presentable(mint.get_accounts(get_detail = options.accounts_ext))
+            data = make_accounts_presentable(mint.get_accounts(
+                get_detail=options.accounts_ext)
+            )
         except:
             data = None
     elif options.transactions:
@@ -375,5 +421,5 @@ def main():
         else:
             raise ValueError('file type must be json for non-transaction data')
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/mintapi/tests.py
+++ b/mintapi/tests.py
@@ -6,20 +6,20 @@ import unittest
 import mintapi
 import mintapi.api
 
-accounts_example = [
-  {
-    "accountName": "Chase Checking", 
+accounts_example = [{
+    "accountName": "Chase Checking",
     "lastUpdated": 1401201492000,
-    "lastUpdatedInString": "25 minutes", 
-    "accountType": "bank", 
+    "lastUpdatedInString": "25 minutes",
+    "accountType": "bank",
     "currentBalance": 100.12,
-  },
-]
+}]
+
 
 class MockResponse:
     def __init__(self, text, status_code=200):
         self.text = text
         self.status_code = status_code
+
 
 class MockSession(mintapi.api.Mint):
     def mount(self, *args, **kwargs):
@@ -32,11 +32,12 @@ class MockSession(mintapi.api.Mint):
         if 'loginUserSubmit' in path:
             text = {'sUser': {'token': 'foo'}}
         elif 'getUserPod' in path:
-            text = {'userPN' : 6}
+            text = {'userPN': 6}
         elif 'bundledServiceController' in path:
             data = json.loads(data['input'])[0]
             text = {'response': {data['id']: {'response': accounts_example}}}
         return MockResponse(json.dumps(text))
+
 
 class MintApiTests(unittest.TestCase):
     def setUp(self):
@@ -54,11 +55,10 @@ class MintApiTests(unittest.TestCase):
 
         accounts_annotated = copy.deepcopy(accounts_example)
         for account in accounts_annotated:
-            account['lastUpdatedInDate'] = datetime.datetime.fromtimestamp(account['lastUpdated']/1000)
+            account['lastUpdatedInDate'] = (datetime.datetime.fromtimestamp(
+                                            account['lastUpdated']/1000))
         self.assertEqual(accounts, accounts_annotated)
 
-        # ensure everything is json serializable as this is the command-line behavior.
+        # ensure everything is json serializable as this is the command-line
+        # behavior.
         mintapi.print_accounts(accounts)
-
-
-


### PR DESCRIPTION
The Python standard library and a lot of other open source libraries choose to follow the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guide for Python code to help make sure code style is consistent and as readable as possible.

This PR takes the existing code and makes numerous improvements to help it match up with PEP8.
There are no changes at all that affect the way the code functions. All the changes are purely formatting.

* One exception: I removed the `import ssl` since it is not being used anywhere in the code.