### PR TITLE
Added PEP8 checking to Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ python:
   - "2.7"
   - "3.4"
 # command to install dependencies
-install: "python setup.py install && pip install nose==1.3.3"
+install: 
+    - python setup.py install
+    - pip install nose flake8 pep8-naming
+before_script:
+    - flake8 mintapi
 # command to run tests
 script: nosetests

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+exclude = mintapi/__init__.py


### PR DESCRIPTION
The Travis CI build now checks for PEP8 compliance and fails the build if things don't line up.