### PR TITLE
Create requirements.txt based on setup.py dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+xmltodict==0.9.2
+requests==2.7.0


### PR DESCRIPTION
This makes it easier for other developers to start working on the project. Now they can just `pip install requirements.txt` and get going.

I left out the optional requirements, like pandas and pypandoc.