### PR TITLE
Fix StringIO issues in Python 3

### DIFF
--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -2,6 +2,11 @@ import json
 import random
 import time
 
+try:
+    from StringIO import StringIO  # Python 2
+except ImportError:
+    from io import BytesIO as StringIO  # Python 3
+
 from datetime import date, datetime, timedelta
 
 import requests
@@ -148,11 +153,6 @@ class Mint(requests.Session):
         if not pd:
             raise ImportError('transactions data requires pandas')
 
-        try:
-            from StringIO import StringIO  # Python 2
-        except ImportError:
-            from io import StringIO  # Python 3
-
         result = self.get(
             'https://wwws.mint.com/transactionDownload.event',
             headers=self.headers
@@ -162,11 +162,7 @@ class Mint(requests.Session):
         if not result.headers['content-type'].startswith('text/csv'):
             raise ValueError('non csv content returned')
 
-        try:
-            s = StringIO(result.content)  # Python 2
-        except Exception:
-            s = StringIO(result.content.decode())  # Python 3
-
+        s = StringIO(result.content)
         s.seek(0)
         df = pd.read_csv(s, parse_dates=['Date'])
         df.columns = [c.lower().replace(' ', '_') for c in df.columns]

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -162,12 +162,10 @@ class Mint(requests.Session):
         if not result.headers['content-type'].startswith('text/csv'):
             raise ValueError('non csv content returned')
 
-        csv_data = result.content
-
         try:
-            s = StringIO(csv_data)  # Python 2
+            s = StringIO(result.content)  # Python 2
         except Exception:
-            s = StringIO(csv_data.decode())  # Python 3
+            s = StringIO(result.content.decode())  # Python 3
 
         s.seek(0)
         df = pd.read_csv(s, parse_dates=['Date'])


### PR DESCRIPTION
The `StringIO` module was moved from the `StringIO` package in Python 2 to the `io` package in Python 3. Lines 150-155 check try the Python 2 import first, then fall back to Python 3, [as prescribed here](http://python3porting.com/stdlib.html).

`result.content` is a `str` object in Python 2, but a `bytes` (Unicode) object in Python 3. We try just shoving it into a StringIO first (the Python 2 way), then fall back to converting the bytes to a string if that fails (the Python 3 way).

Nosetests pass on Python 2 and 3. Getting transactions passes in both 2 and 3 as well, tested with this script:

```
import mintapi
mint = mintapi.Mint('matt@mplewis.com', 'chocolate-chip-cookie-dough')
txns = mint.get_transactions()
```