### PR TITLE
Factor out get_transactions_csv API method for retrieving raw CSV data

### DIFF
--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -149,6 +149,24 @@ class Mint(requests.Session):
             accounts = self.populate_extended_account_detail(accounts)
         return accounts
 
+    def set_user_property(self, name, value):
+        url = 'https://wwws.mint.com/bundledServiceController.xevent?legacy=false&token=' + self.token
+        req_id = str(self.request_id)
+        self.request_id += 1
+        result = self.post(
+            url,
+            data = {'input': json.dumps([{'args': {'propertyName': name,
+                                                   'propertyValue': value},
+                                          'service': 'MintUserService',
+                                          'task': 'setUserProperty',
+                                          'id': req_id}])},
+            headers=self.json_headers)
+        if result.status_code != 200:
+            raise Exception('Received HTTP error %d' % result.status_code)
+        response = result.text
+        if req_id not in response:
+            raise Exception("Could not parse response to set_user_property")
+
     def get_transactions_csv(self):
         """Returns the raw CSV transaction data as downloaded from Mint.
         """

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -167,11 +167,20 @@ class Mint(requests.Session):
         if req_id not in response:
             raise Exception("Could not parse response to set_user_property")
 
-    def get_transactions_csv(self):
+    def get_transactions_csv(self, include_investment = False):
         """Returns the raw CSV transaction data as downloaded from Mint.
+
+        If include_investment == True, also includes transactions that Mint
+        classifies as investment-related.  You may find that the investment
+        transaction data is not sufficiently detailed to actually be useful,
+        however.
         """
+
+        # Specifying accountId=0 causes Mint to return investment
+        # transactions as well.  Otherwise they are skipped by
+        # default.
         result = self.get(
-            'https://wwws.mint.com/transactionDownload.event',
+            'https://wwws.mint.com/transactionDownload.event' + ('?accountId=0' if include_investment else ''),
             headers=self.headers
             )
         if result.status_code != 200:

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -67,8 +67,8 @@ class Mint(requests.Session):
         except ValueError:
             return None
 
-    def request_and_check(self, url, method = 'get',
-                          expected_content_type = None, **kwargs):
+    def request_and_check(self, url, method='get',
+                          expected_content_type=None, **kwargs):
         """Performs a request, and checks that the status is OK, and that the
         content-type matches expectations.
 
@@ -87,7 +87,7 @@ class Mint(requests.Session):
             raise RuntimeError('Error requesting %r, status = %d' %
                                (url, result.status_code))
         if expected_content_type is not None:
-            content_type = result.headers.get('content-type','')
+            content_type = result.headers.get('content-type', '')
             if not content_type.startswith(expected_content_type):
                 raise RuntimeError(
                     'Error requesting %r, content type %r does not match %r' %
@@ -103,8 +103,8 @@ class Mint(requests.Session):
         login_url = 'https://wwws.mint.com/login.event?task=L'
         try:
             self.request_and_check(login_url)
-        except RuntimeError as e:
-            raise Exception('Failed to load Mint login page') from e
+        except RuntimeError:
+            raise Exception('Failed to load Mint login page')
 
         data = {'username': email}
         response = self.post('https://wwws.mint.com/getUserPod.xevent',
@@ -232,8 +232,9 @@ class Mint(requests.Session):
                     query_options=(
                         'accountId=0&task=transactions' if include_investment
                         else 'task=transactions,txnfilters&filterType=cash'))
-            result = self.request_and_check(url, headers = self.json_headers,
-                                            expected_content_type = 'text/json')
+            result = self.request_and_check(
+                url, headers=self.json_headers,
+                expected_content_type='text/json')
             data = json.loads(result.text)
             txns = data['set'][0].get('data', [])
             if not txns:
@@ -259,7 +260,7 @@ class Mint(requests.Session):
             'https://wwws.mint.com/transactionDownload.event' +
             ('?accountId=0' if include_investment else ''),
             headers=self.headers,
-            expected_content_type = 'text/csv'
+            expected_content_type='text/csv'
             )
         return result.content
 


### PR DESCRIPTION
This simply separates the logic for retrieving the CSV transactions data from
the logic for parsing it as a Pandas DataFrame.  This allows users to retrieve
the raw transaction data without depending on Pandas.