### PR TITLE
Catch exception for urllib3

### DIFF
--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -12,7 +12,10 @@ from datetime import date, datetime, timedelta
 import requests
 
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.poolmanager import PoolManager
+try:
+        from requests.packages.urllib3.poolmanager import PoolManager
+except:
+        from urllib3.poolmanager import PoolManager #Ubuntu 14.01+ issues fixed
 
 import xmltodict
 


### PR DESCRIPTION
Ubuntu 14.01+ and other Debian distros do not have urllib3 in the request library but in a separate one.