### PR TITLE
Exception urllib3 lib

### DIFF
--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -12,7 +12,11 @@ from datetime import date, datetime, timedelta
 import requests
 
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.poolmanager import PoolManager
+
+try:
+        from requests.packages.urllib3.poolmanager import PoolManager
+except:
+        from urllib3.poolmanager import PoolManager # Ubuntu issues
 
 import xmltodict
 


### PR DESCRIPTION
Ubuntu 14.01+ and other Debian distros do not have urllib3 in the request library