### PR TITLE
replaced text/json with application/json

### DIFF
--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -265,7 +265,7 @@ class Mint(requests.Session):
                         else 'task=transactions,txnfilters&filterType=cash'))
             result = self.request_and_check(
                 url, headers=self.json_headers,
-                expected_content_type='text/json')
+                expected_content_type='application/json')
             data = json.loads(result.text)
             txns = data['set'][0].get('data', [])
             df = pd.DataFrame(txns)


### PR DESCRIPTION
This pull request is to address the error: 'application/son;charset=UTF-8' does not match 'text/json' when calling mint.get_transactions_json()