### PR TITLE
Add exception handling to account for changes in Python 3

### DIFF
--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -604,6 +604,8 @@ def main():
         from __builtin__ import raw_input as input
     except NameError:
         pass
+    except ImportError:
+        from builtins import input as input #Python 3
 
     # Try to get the e-mail and password from the arguments
     email = options.email

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -605,7 +605,7 @@ def main():
     except NameError:
         pass
     except ImportError:
-        from builtins import input as input #Python 3
+        from builtins import input as input  # Python 3
 
     # Try to get the e-mail and password from the arguments
     email = options.email


### PR DESCRIPTION
'**builtin**' module has been renamed to 'builtins' and 'raw_input' to 'input' in Python3. One I added the exception handling I was able to get the api to work in P3.
