### PR TITLE
add method to refresh accounts and wait to finish

### DIFF
--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -622,6 +622,8 @@ def main():
     cmdline.add_argument('--keyring', action='store_true',
                          help='Use OS keyring for storing password '
                          'information')
+    cmdline.add_argument('--wait-for-account-refresh', action='store_true',
+                         default=False, help='Initiate account refresh on Mint.com and wait for refresh to finish before executing other commands')
 
     options = cmdline.parse_args()
 
@@ -663,6 +665,9 @@ def main():
         options.accounts = True
 
     mint = Mint.create(email, password)
+
+    if options.wait_for_account_refresh:
+        mint.refresh_accounts()
 
     data = None
     if options.accounts and options.budgets:

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -236,7 +236,6 @@ class Mint(requests.Session):
         interface.  Note that the CSV transactions never exclude duplicates.
         """
 
-
         # Warning: This is a global property for the user that we are changing.
         self.set_user_property('hide_duplicates',
                                'T' if skip_duplicates else 'F')
@@ -532,7 +531,8 @@ class Mint(requests.Session):
         waited = 0
         while True:
             result = self.request_and_check(
-                'https://wwws.mint.com/userStatus.xevent?rnd='+str(random.randint(0, 10**14)),
+                'https://wwws.mint.com/userStatus.xevent?rnd=' +
+                str(random.randint(0, 10**14)),
                 headers=self.json_headers,
                 expected_content_type='application/json')
             data = json.loads(result.text)
@@ -543,6 +543,7 @@ class Mint(requests.Session):
             else:
                 waited += 1
                 time.sleep(refresh_every)
+
 
 def get_accounts(email, password, get_detail=False):
     mint = Mint.create(email, password)
@@ -605,17 +606,25 @@ def main():
                          'implies --accounts)')
     cmdline.add_argument('--transactions', '-t', action='store_true',
                          default=False, help='Retrieve transactions')
-    cmdline.add_argument('--extended-transactions',action='store_true',default=False,
-                         help='Retrieve transactions with extra information and arguments')
-    cmdline.add_argument('--start-date',nargs='?',default=None,
-                         help='Earliest date for transactions to be retrieved from. Used with --extended-transactions. Format: mm/dd/yy')
-    cmdline.add_argument('--include-investment',action='store_true',default=False,
+    cmdline.add_argument('--extended-transactions', action='store_true',
+                         default=False,
+                         help='Retrieve transactions with extra '
+                         'information and arguments')
+    cmdline.add_argument('--start-date', nargs='?', default=None,
+                         help='Earliest date for transactions to be '
+                         'retrieved from. Used with --extended-transactions. '
+                         'Format: mm/dd/yy')
+    cmdline.add_argument('--include-investment', action='store_true',
+                         default=False,
                          help='Used with --extended-transactions')
-    cmdline.add_argument('--skip-duplicates',action='store_true',default=False,
+    cmdline.add_argument('--skip-duplicates', action='store_true',
+                         default=False,
                          help='Used with --extended-transactions')
-# Displayed to the user as a postive switch, but processed back here as a negative
-    cmdline.add_argument('--show-pending',action='store_false',default=True,
-                         help='Exclude pending transactions from being retrieved. Used with --extended-transactions')
+# Displayed to the user as a postive switch,
+# but processed back here as a negative
+    cmdline.add_argument('--show-pending', action='store_false', default=True,
+                         help='Exclude pending transactions from being '
+                         'retrieved. Used with --extended-transactions')
     cmdline.add_argument('--filename', '-f', help='write results to file. can '
                          'be {csv,json} format. default is to write to '
                          'stdout.')
@@ -623,7 +632,9 @@ def main():
                          help='Use OS keyring for storing password '
                          'information')
     cmdline.add_argument('--wait-for-account-refresh', action='store_true',
-                         default=False, help='Initiate account refresh on Mint.com and wait for refresh to finish before executing other commands')
+                         default=False, help='Initiate account refresh on '
+                         'Mint.com and wait for refresh to finish before '
+                         'executing other commands')
 
     options = cmdline.parse_args()
 
@@ -664,7 +675,10 @@ def main():
     if options.accounts_ext:
         options.accounts = True
 
-    if not any([options.accounts, options.budgets, options.transactions, options.extended_transactions,
+    if not any([options.accounts,
+                options.budgets,
+                options.transactions,
+                options.extended_transactions,
                 options.net_worth]):
         options.accounts = True
 
@@ -703,10 +717,11 @@ def main():
     elif options.transactions:
         data = mint.get_transactions()
     elif options.extended_transactions:
-        data = mint.get_detailed_transactions(start_date=options.start_date,
-                                              include_investment=options.include_investment,
-                                              remove_pending=options.show_pending,
-                                              skip_duplicates=options.skip_duplicates
+        data = mint.get_detailed_transactions(
+                start_date=options.start_date,
+                include_investment=options.include_investment,
+                remove_pending=options.show_pending,
+                skip_duplicates=options.skip_duplicates
         )
     elif options.net_worth:
         data = mint.get_net_worth()

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -647,7 +647,11 @@ def main():
     if keyring and not password:
         # If the keyring module is installed and we don't yet have
         # a password, try prompting for it
-        password = keyring.get_password('mintapi', email)
+        try:
+            password = keyring.get_password('mintapi', email)
+        except:
+            print("Cannot access system keyring")
+            options.keyring = False
 
     if not password:
         # If we still don't have a password, prompt for it


### PR DESCRIPTION
Add `refresh_accounts()` to make sure that accounts are up-to-date on Mint by waiting for account refresh to finish.

Also add an command-line option --wait-for-account-refresh
https://github.com/mrooney/mintapi/pull/75/commits/620faf3ea68619e6f94aa295d507f9ab0c1bc81e

Addressing issue #70.
