### PR TITLE
add history to get_budget

### DIFF
--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -518,7 +518,7 @@ class Mint(requests.Session):
 
         return categories
 
-    def get_budgets(self):  # {{{
+    def get_budgets(self, hist=None):  # {{{
         # Issue request for budget utilization
         today = date.today()
         this_month = date(today.year, today.month, 1)
@@ -533,14 +533,14 @@ class Mint(requests.Session):
             headers=self.json_headers
         ).text)
 
-        if hist is not None: # version proofing api
+        if hist is not None:  # version proofing api
             def mos_to_yrmo(mos_frm_zero):
-                date_yr_mo = datetime(year=int(mos_frm_zero/12), month=mos_frm_zero%12 + 1, day = 1).strftime("%Y%m")
+                date_yr_mo = datetime(year=int(mos_frm_zero / 12), month=mos_frm_zero % 12 + 1, day=1).strftime("%Y%m")
                 return date_yr_mo
 
             # Error checking 'hist' argument
             if isinstance(hist, str) or hist > 12:
-                hist = 12 # MINT_ROOT_URL only calls last 12 months of budget data
+                hist = 12  # MINT_ROOT_URL only calls last 12 months of budget data
             elif hist < 1:
                 hist = 1
 

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -535,7 +535,9 @@ class Mint(requests.Session):
 
         if hist is not None:  # version proofing api
             def mos_to_yrmo(mos_frm_zero):
-                date_yr_mo = datetime(year=int(mos_frm_zero / 12), month=mos_frm_zero % 12 + 1, day=1).strftime("%Y%m")
+                date_yr_mo = datetime(year=int(mos_frm_zero / 12),
+                                      month=mos_frm_zero % 12 + 1,
+                                      day=1).strftime("%Y%m")
                 return date_yr_mo
 
             # Error checking 'hist' argument
@@ -554,9 +556,23 @@ class Mint(requests.Session):
             budgets = {}
             for months in range(bgt_cur_mo, min_mo_hist, -1):
                 budgets[mos_to_yrmo(months)] = {}
-                budgets[mos_to_yrmo(months)]["income"] = response["data"]["income"][str(months)]['bu']
-                budgets[mos_to_yrmo(months)]["spending"] = response["data"]["spending"][str(months)]['bu']
+                budgets[mos_to_yrmo(months)]["income"] = response["data"][
+                                                "income"][str(months)]['bu']
+                budgets[mos_to_yrmo(months)]["spending"] = response["data"][
+                                                "spending"][str(months)]['bu']
 
+            # Get categories
+            categories = self.get_categories()
+            
+            # Fill in the return structure
+            for month in budgets.keys():
+                for direction in budgets[month]:
+                    for budget in budgets[month][direction]:
+                        budget['cat'] = self.get_category_from_id(
+                            budget['cat'],
+                            categories
+                        )
+    
         else:
             # Get categories
             categories = self.get_categories()

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -535,10 +535,9 @@ class Mint(requests.Session):
 
         if hist is not None:  # version proofing api
             def mos_to_yrmo(mos_frm_zero):
-                date_yr_mo = datetime(year=int(mos_frm_zero / 12),
-                                      month=mos_frm_zero % 12 + 1,
-                                      day=1).strftime("%Y%m")
-                return date_yr_mo
+                return datetime(year=int(mos_frm_zero / 12),
+                                month=mos_frm_zero % 12 + 1,
+                                day=1).strftime("%Y%m")
 
             # Error checking 'hist' argument
             if isinstance(hist, str) or hist > 12:
@@ -556,14 +555,14 @@ class Mint(requests.Session):
             budgets = {}
             for months in range(bgt_cur_mo, min_mo_hist, -1):
                 budgets[mos_to_yrmo(months)] = {}
-                budgets[mos_to_yrmo(months)]["income"] = response["data"][
-                                                "income"][str(months)]['bu']
-                budgets[mos_to_yrmo(months)]["spending"] = response["data"][
-                                                "spending"][str(months)]['bu']
+                budgets[mos_to_yrmo(months)][
+                    "income"] = response["data"]["income"][str(months)]['bu']
+                budgets[mos_to_yrmo(months)][
+                    "spending"] = response["data"]["spending"][str(months)]['bu']
 
             # Get categories
             categories = self.get_categories()
-            
+
             # Fill in the return structure
             for month in budgets.keys():
                 for direction in budgets[month]:
@@ -572,7 +571,7 @@ class Mint(requests.Session):
                             budget['cat'],
                             categories
                         )
-    
+
         else:
             # Get categories
             categories = self.get_categories()
@@ -671,6 +670,8 @@ def main():
                          ' (default if nothing else is specified)')
     cmdline.add_argument('--budgets', action='store_true', dest='budgets',
                          default=False, help='Retrieve budget information')
+    cmdline.add_argument('--budget_hist', action='store_true', dest='budget_hist',
+                         default=None, help='Retrieve 12-month budget history information')
     cmdline.add_argument('--net-worth', action='store_true', dest='net_worth',
                          default=False, help='Retrieve net worth information')
     cmdline.add_argument('--extended-accounts', action='store_true',
@@ -760,6 +761,11 @@ def main():
     elif options.budgets:
         try:
             data = mint.get_budgets()
+        except:
+            data = None
+    elif options.budget_hist:
+        try:
+            data = mint.get_budgets(hist=12)
         except:
             data = None
     elif options.accounts:

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -519,10 +519,6 @@ class Mint(requests.Session):
         return categories
 
     def get_budgets(self):  # {{{
-
-        # Get categories
-        categories = self.get_categories()
-
         # Issue request for budget utilization
         today = date.today()
         this_month = date(today.year, today.month, 1)
@@ -537,23 +533,51 @@ class Mint(requests.Session):
             headers=self.json_headers
         ).text)
 
-        # Make the skeleton return structure
-        budgets = {
-            'income': response['data']['income'][
-                str(max(map(int, response['data']['income'].keys())))
-            ]['bu'],
-            'spend': response['data']['spending'][
-                str(max(map(int, response['data']['income'].keys())))
-            ]['bu']
-        }
+        if hist is not None: # version proofing api
+            def mos_to_yrmo(mos_frm_zero):
+                date_yr_mo = datetime(year=int(mos_frm_zero/12), month=mos_frm_zero%12 + 1, day = 1).strftime("%Y%m")
+                return date_yr_mo
 
-        # Fill in the return structure
-        for direction in budgets.keys():
-            for budget in budgets[direction]:
-                budget['cat'] = self.get_category_from_id(
-                    budget['cat'],
-                    categories
-                )
+            # Error checking 'hist' argument
+            if isinstance(hist, str) or hist > 12:
+                hist = 12 # MINT_ROOT_URL only calls last 12 months of budget data
+            elif hist < 1:
+                hist = 1
+
+            bgt_cur_mo = max(map(int, response['data']['income'].keys()))
+            min_mo_hist = bgt_cur_mo - hist
+
+            # Initialize and populate dictionary for return
+            #   Output 'budgets' dictionary with structure
+            #       { "YYYYMM": {"spending": [{"key": value, ...}, ...],
+            #                      "income": [{"key": value, ...}, ...] } }
+            budgets = {}
+            for months in range(bgt_cur_mo, min_mo_hist, -1):
+                budgets[mos_to_yrmo(months)] = {}
+                budgets[mos_to_yrmo(months)]["income"] = response["data"]["income"][str(months)]['bu']
+                budgets[mos_to_yrmo(months)]["spending"] = response["data"]["spending"][str(months)]['bu']
+
+        else:
+            # Get categories
+            categories = self.get_categories()
+
+            # Make the skeleton return structure
+            budgets = {
+                'income': response['data']['income'][
+                    str(max(map(int, response['data']['income'].keys())))
+                ]['bu'],
+                'spend': response['data']['spending'][
+                    str(max(map(int, response['data']['income'].keys())))
+                ]['bu']
+            }
+
+            # Fill in the return structure
+            for direction in budgets.keys():
+                for budget in budgets[direction]:
+                    budget['cat'] = self.get_category_from_id(
+                        budget['cat'],
+                        categories
+                    )
 
         return budgets
 


### PR DESCRIPTION
I also wanted a budget history so I can trend my budget actuals in my local monthly budget tool.
I looked into this and worked a solution. 
Currently, the 'budgets' dictionary in the api is being created just with the max month number (ie most current). I implemented a 'hist' argument in 'get_budget()' that allows for a select-able range from 1-12 months.
I sling code but don't claim to be efficient, so pythonic edits are welcome.
Closes Issue #66 