### PR TITLE
Removing parent categoryId check when building category list

### DIFF
--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -512,8 +512,6 @@ class Mint(requests.Session):
         # Build category list
         categories = {}
         for category in response['allCategories']:
-            if category['parentId'] == 0:
-                continue
             categories[category['id']] = category
 
         return categories


### PR DESCRIPTION
I was running into "Unknown" budget names with the --budgets option in this [issue](https://github.com/mrooney/mintapi/issues/96).

Some of my budgets would have the correct name but others said "Unknown":

```json
    {
      "catTypeFilter": "Personal", 
      "ramt": 0, 
      "cat": "Unknown", 
      "pid": null, 
      "amt": 96.25, 
      "isIncome": false, 
      "isTransfer": false, 
      "bgt": 150.0, 
      "ex": false, 
      "id": 56418312, 
      "st": 1, 
      "type": 0, 
      "isExpense": true, 
      "rbal": 53.75
    }, 
```

To me it looks like get_categories() is only used when getting budgets and removing the check to see if the parentId was set to 0 seemed to solve my problem, but maybe this check is in place for a good reason?