### PR TITLE
str and error concatenation TypeError + small grammar fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ make calls to retrieve account/budget information.  We recommend using the
 ```
 
 You will notice the login step requires an ius_session and thx_guid.  These are session
-cookies that must persists. If you choose not to install selenium and chromedriver, you must obtain these values by searching your browser's cookies.
+cookies that must persist. If you choose not to install selenium and chromedriver, you must obtain these values by searching your browser's cookies.
 In Chrome, for example, visit chrome://settings/cookies and type intuit (*not* mint).  Alternatively, you
 can login to Mint manually with your browser in inspect mode and poke around in the network tab.
 Providing these two cookies eliminates the need to 2-step authenticate.  Mint requires this with

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -180,7 +180,7 @@ class Mint(requests.Session):
                                "the chromedriver selenium plugin. Please ensure "
                                "that the `selenium` and `chromedriver` packages "
                                "are installed.\n\nThe original error message was: " +
-                               (e.args[0] if len(e.args) > 0 else 'No error message found.'))
+                               (str(e.args[0]) if len(e.args) > 0 else 'No error message found.'))
 
         driver.get("https://www.mint.com")
         driver.implicitly_wait(20)  # seconds


### PR DESCRIPTION
Fixes `TypeError: cannot concatenate 'str' and 'error' objects` being printed instead of the RuntimeError message and original error as desired. This bug occurs when webdriver raises a URLError (for example `[Errno 61] Connection refused`).

Also made a tiny grammar fix in the Readme.