### PR TITLE
Fix get_transactions_json when start_date predates all transactions

### DIFF
--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -600,7 +600,6 @@ def get_net_worth(email, password):
     return mint.get_net_worth(account_data)
 
 
-
 def make_accounts_presentable(accounts, presentable_format='EXCEL'):
     formatter = {
         'DATE': '%Y-%m-%d',

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -343,14 +343,14 @@ class Mint(requests.Session):
                 expected_content_type='text/json|application/json')
             data = json.loads(result.text)
             txns = data['set'][0].get('data', [])
+            if not txns:
+                break
             if start_date:
                 last_dt = self._dateconvert(txns[-1]['odate'])
                 if last_dt < start_date:
                     keep_txns = [t for t in txns if self._dateconvert(t['odate']) >= start_date]
                     all_txns.extend(keep_txns)
                     break
-            if not txns:
-                break
             all_txns.extend(txns)
             offset += len(txns)
         return all_txns


### PR DESCRIPTION
If start_date is before the earliest/first transaction the if start_date block errors out, since txns is empty. To handle this, simply re-order the blocks.