### PR TITLE
Automate mfa-code retrieval from email via IMAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,15 +69,6 @@ make calls to retrieve account/budget information.  We recommend using the
   mint.get_transactions_csv(include_investment=False) # as raw csv data
   mint.get_transactions_json(include_investment=False, skip_duplicates=False)
 
-  # Get transaction data separately for each account
-  # adding the key "id" identifying the acount to each transaction
-  # include_investment must be set to True, even for non-investment accounts
-  for account in accounts:
-    trans = mint.get_transactions_json(include_investment=True, skip_duplicates=False, id=account["id"], start_date=monthago)
-    for tran in trans:
-      tran["id"] = account["id"]
-    print(trans)
-
   # Get net worth
   mint.get_net_worth()
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ an MFA prompt, you'll be prompted on the command line for your code, which by de
 goes to SMS unless you specify `--mfa-method=email`. This will also persist a browser
 session in $HOME/.mintapi/session to avoid an MFA in the future, unless you specify `--session-path=None`.
 
+If mfa-method is email and your email host provides IMAP access, you can specify your IMAP login details.  This will automate the retrieval of the MFA code from your email and entering it into Mint.
+
 ### from Python
 
 From python, instantiate the Mint class (from the mintapi package) and you can
@@ -52,6 +54,10 @@ make calls to retrieve account/budget information.  We recommend using the
                        # To avoid the 2FA code being asked for multiple times, you can either set
                        # this parameter or log in by hand in Chrome under the same user this runs
                        # as.
+    imap_account=None, # account name used to log in to your IMAP server
+    imap_password=None, # account password used to log in to your IMAP server
+    imap_server=None,  # IMAP server host name
+    imap_folder='INBOX',  # IMAP folder that receives MFA email
   )
 
   # Get basic account information
@@ -108,8 +114,7 @@ Run it as a sub-process from your favorite language; `pip install mintapi` creat
                             profile.
       --budgets             Retrieve budget information
       --net-worth           Retrieve net worth information
-      --extended-accounts   Retrieve extended account information (slower, implies
-                            --accounts)
+      --extended-accounts   Retrieve extended account information (slower, implies --accounts)
       --transactions, -t    Retrieve transactions
       --extended-transactions
                             Retrieve transactions with extra information and
@@ -129,6 +134,13 @@ Run it as a sub-process from your favorite language; `pip install mintapi` creat
                             window.
       --mfa-method {sms,email}
                             The MFA method to automate.
+      --imap-account IMAP_ACCOUNT
+      --imap-password IMAP_PASSWORD
+      --imap-server IMAP_SERVER_HOSTNAME
+      --imap-folder IMAP_FOLDER
+                            Default is INBOX
+      --imap-test           Test access to IMAP server
+
     >>> mintapi --keyring email@example.com
     [
       {

--- a/README.md
+++ b/README.md
@@ -69,6 +69,15 @@ make calls to retrieve account/budget information.  We recommend using the
   mint.get_transactions_csv(include_investment=False) # as raw csv data
   mint.get_transactions_json(include_investment=False, skip_duplicates=False)
 
+  # Get transaction data separately for each account
+  # adding the key "id" identifying the acount to each transaction
+  # include_investment must be set to True, even for non-investment accounts
+  for account in accounts:
+    trans = mint.get_transactions_json(include_investment=True, skip_duplicates=False, id=account["id"], start_date=monthago)
+    for tran in trans:
+      tran["id"] = account["id"]
+    print(trans)
+
   # Get net worth
   mint.get_net_worth()
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ make calls to retrieve account/budget information.  We recommend using the
   mint.get_transactions_csv(include_investment=False) # as raw csv data
   mint.get_transactions_json(include_investment=False, skip_duplicates=False)
 
+  # Get transactions for a specific account
+  accounts = mint.get_accounts(True)
+  for account in accounts:
+    mint.get_transactions_csv(id=account["id"])
+    mint.get_transactions_json(id=account["id"])
+
   # Get net worth
   mint.get_net_worth()
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ an MFA prompt, you'll be prompted on the command line for your code, which by de
 goes to SMS unless you specify `--mfa-method=email`. This will also persist a browser
 session in $HOME/.mintapi/session to avoid an MFA in the future, unless you specify `--session-path=None`.
 
-If mfa-method is email and your email host provides IMAP access, you can specify your IMAP login details.  This will automate the retrieval of the MFA code from your email and entering it into Mint.
+If mfa-method is email and your email host provides IMAP access, you can specify your IMAP login details.
+This will automate the retrieval of the MFA code from your email and entering it into Mint.
 
 ### from Python
 
@@ -44,7 +45,8 @@ make calls to retrieve account/budget information.  We recommend using the
     'password',  # Your password used to log in to mint
     # Optional parameters
     mfa_method='sms',  # Can be 'sms' (default) or 'email'.
-                       # if mintapi detects an MFA request, it will trigger the requested method and prompt on the command line.
+                       # if mintapi detects an MFA request, it will trigger the requested method
+                       # and prompt on the command line.
     headless=False,  # Whether the chromedriver should work without opening a
                      # visible window (useful for server-side deployments)
     mfa_input_callback=None,  # A callback accepting a single argument (the prompt)

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -362,7 +362,7 @@ class Mint(object):
                 'Could not parse response to set_user_property')
 
     def get_transactions_json(self, include_investment=False,
-                              skip_duplicates=False, start_date=None):
+                              skip_duplicates=False, start_date=None, id=0):
         """Returns the raw JSON transaction data as downloaded from Mint.  The JSON
         transaction data includes some additional information missing from the
         CSV data, such as whether the transaction is pending or completed, but
@@ -399,7 +399,8 @@ class Mint(object):
                 offset=offset,
                 rnd=Mint.get_rnd(),
                 query_options=(
-                    'accountId=0&task=transactions' if include_investment
+                    'accountId=' + str(id) + '&task=transactions' if include_investment
+                    else 'accountId=' + str(id) + '&task=transactions,txnfilters&filterType=cash' if id > 0
                     else 'task=transactions,txnfilters&filterType=cash'))
             result = self.request_and_check(
                 url, headers=JSON_HEADER,
@@ -453,7 +454,7 @@ class Mint(object):
 
         return df
 
-    def get_transactions_csv(self, include_investment=False):
+    def get_transactions_csv(self, include_investment=False, acct=0):
         """Returns the raw CSV transaction data as downloaded from Mint.
 
         If include_investment == True, also includes transactions that Mint
@@ -467,7 +468,7 @@ class Mint(object):
         # default.
         result = self.request_and_check(
             '{}/transactionDownload.event'.format(MINT_ROOT_URL) +
-            ('?accountId=0' if include_investment else ''),
+            ('?accountId=' + str(acct) if include_investment or acct > 0 else ''),
             expected_content_type='text/csv')
         return result.content
 

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -362,7 +362,7 @@ class Mint(object):
                 'Could not parse response to set_user_property')
 
     def get_transactions_json(self, include_investment=False,
-                              skip_duplicates=False, start_date=None, id=0):
+                              skip_duplicates=False, start_date=None):
         """Returns the raw JSON transaction data as downloaded from Mint.  The JSON
         transaction data includes some additional information missing from the
         CSV data, such as whether the transaction is pending or completed, but
@@ -399,7 +399,7 @@ class Mint(object):
                 offset=offset,
                 rnd=Mint.get_rnd(),
                 query_options=(
-                    'accountId=' + str(id) + '&task=transactions' if include_investment
+                    'accountId=0&task=transactions' if include_investment
                     else 'task=transactions,txnfilters&filterType=cash'))
             result = self.request_and_check(
                 url, headers=JSON_HEADER,
@@ -453,7 +453,7 @@ class Mint(object):
 
         return df
 
-    def get_transactions_csv(self, include_investment=False, acct=0):
+    def get_transactions_csv(self, include_investment=False):
         """Returns the raw CSV transaction data as downloaded from Mint.
 
         If include_investment == True, also includes transactions that Mint
@@ -467,7 +467,7 @@ class Mint(object):
         # default.
         result = self.request_and_check(
             '{}/transactionDownload.event'.format(MINT_ROOT_URL) +
-            ('?accountId=' + str(acct) if include_investment else ''),
+            ('?accountId=0' if include_investment else ''),
             expected_content_type='text/csv')
         return result.content
 

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -219,6 +219,7 @@ def get_web_driver(email, password, headless=False, mfa_method=None,
         element = driver.find_element_by_link_text("LOG IN")
         driver.implicitly_wait(20)  # seconds
     element.click()
+    time.sleep(1)
     driver.find_element_by_id("ius-userid").send_keys(email)
     driver.find_element_by_id("ius-password").send_keys(password)
     driver.find_element_by_id("ius-sign-in-submit-btn").submit()
@@ -1023,7 +1024,7 @@ def main():
     atexit.register(mint.close)  # Ensure everything is torn down.
 
     if options.imap_test:
-        mfa_code = mint.get_email_code(options.imap_account, options.imap_password, options.imap_server, imap_folder=options.imap_folder, debug=1, delete=0)
+        mfa_code = get_email_code(options.imap_account, options.imap_password, options.imap_server, imap_folder=options.imap_folder, debug=1, delete=0)
         print("MFA CODE:", mfa_code)
         sys.exit()
 

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -76,7 +76,7 @@ def get_email_code(imap_account, imap_password, imap_server, imap_folder, debug=
 
         rv, data = M.search(None, "ALL")
         if rv != 'OK':
-            print("ERROR: Email search failed for", sys.argv[1])
+            print("ERROR: Email search failed")
             return '';
 
         count = 0;

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -362,7 +362,7 @@ class Mint(object):
                 'Could not parse response to set_user_property')
 
     def get_transactions_json(self, include_investment=False,
-                              skip_duplicates=False, start_date=None):
+                              skip_duplicates=False, start_date=None, id=0):
         """Returns the raw JSON transaction data as downloaded from Mint.  The JSON
         transaction data includes some additional information missing from the
         CSV data, such as whether the transaction is pending or completed, but
@@ -399,7 +399,7 @@ class Mint(object):
                 offset=offset,
                 rnd=Mint.get_rnd(),
                 query_options=(
-                    'accountId=0&task=transactions' if include_investment
+                    'accountId=' + str(id) + '&task=transactions' if include_investment
                     else 'task=transactions,txnfilters&filterType=cash'))
             result = self.request_and_check(
                 url, headers=JSON_HEADER,
@@ -453,7 +453,7 @@ class Mint(object):
 
         return df
 
-    def get_transactions_csv(self, include_investment=False):
+    def get_transactions_csv(self, include_investment=False, acct=0):
         """Returns the raw CSV transaction data as downloaded from Mint.
 
         If include_investment == True, also includes transactions that Mint
@@ -467,7 +467,7 @@ class Mint(object):
         # default.
         result = self.request_and_check(
             '{}/transactionDownload.event'.format(MINT_ROOT_URL) +
-            ('?accountId=0' if include_investment else ''),
+            ('?accountId=' + str(acct) if include_investment else ''),
             expected_content_type='text/csv')
         return result.content
 


### PR DESCRIPTION
This change allows mintapi to run autonomously, even when Mint requires MFA.  If mfa-method is email and your email host provides IMAP access, you can specify your IMAP login details.  This will automate the retrieval of the MFA code from your email and entering it into Mint.

There is a also a small change to allow an account to be specified when calling mint.get_transactions_json and _csv.
