### PR TITLE
Full Credit Report API

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Run it as a sub-process from your favorite language; `pip install mintapi` creat
 ```shell
     usage: mintapi [-h] [--session-path [SESSION_PATH]] [--accounts]
                    [--budgets] [--net-worth] [--extended-accounts] [--transactions]
-                   [--extended-transactions] [--credit-score] [--start-date [START_DATE]]
+                   [--extended-transactions] [--credit-score] [--credit-report] [--start-date [START_DATE]]
                    [--include-investment] [--skip-duplicates] [--show-pending]
                    [--filename FILENAME] [--keyring] [--headless]
                    [--mfa-method {sms,email}]
@@ -105,6 +105,7 @@ Run it as a sub-process from your favorite language; `pip install mintapi` creat
                             profile.
       --budgets             Retrieve budget information
       --credit-score        Retrieve credit score
+      --credit-report       Retrieve full credit report & history
       --net-worth           Retrieve net worth information
       --extended-accounts   Retrieve extended account information (slower, implies
                             --accounts)


### PR DESCRIPTION
I was playing around with Mint, and figured out how their Credit Report API works - a more robust solution to getting the credit score, as it also pulls in all prior credit reports (not just the current one), and metadata / history about all of the metrics that contribute to the score.

The Credit Report API is on a different domain (https://credit.finance.intuit.com), and uses a different authorization scheme. There are 4 data endpoints, and an additional metadata endpoint.

**Authorization**
The Credit API uses an authorization header and API key. The API key is saved to the window scope in JavaScript on page load, and can be retrieved by returning `window.MintConfig.browserAuthAPIKey`. Then, pass the token in an authorization header with the value `Intuit_APIKey intuit_apikey={api_key}` when requesting data from any of the end points. All of these support `GET` requests.

**Endpoints**
- **/v1/creditreports**: this takes one parameter (limit=#), and returns up to that many credit reports. Mint loads 2 by default, but they store way more - at least 8, but potentially every report since they switched to TransUnion in ~2017.
- **/v1/creditreports/0/inquiries**: full list of credit inquiries from the latest credit report.
- **/v1/creditreports/0/tradelines**: full list of credit accounts, and their details from the latest credit report.
- **/v1/creditreports/creditutilizationhistory**: a limited credit utilization history by account, going back about 3 months.

Info about how the credit bands are defined can be found by hitting **/v1/creditscoreproviders/3**, but this also includes a large amount of HTML snippets and styling information.