### PR TITLE
Add soft token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ session in $HOME/.mintapi/session to avoid an MFA in the future, unless you spec
 If mfa-method is email and your email host provides IMAP access, you can specify your IMAP login details.
 This will automate the retrieval of the MFA code from your email and entering it into Mint.
 
+If mfa-method is soft-token then you must also pass your mfa-token.
+
 ### from Python
 
 From python, instantiate the Mint class (from the mintapi package) and you can
@@ -111,7 +113,7 @@ Run it as a sub-process from your favorite language; `pip install mintapi` creat
                    [--extended-transactions] [--credit-score] [--credit-report] [--start-date [START_DATE]]
                    [--include-investment] [--skip-duplicates] [--show-pending]
                    [--filename FILENAME] [--keyring] [--headless] [--attention]
-                   [--mfa-method {sms,email}]
+                   [--mfa-method {sms,email,soft-token}]
                    email [password]
 
     positional arguments:
@@ -152,8 +154,9 @@ Run it as a sub-process from your favorite language; `pip install mintapi` creat
 	  --use-chromedriver-on-path
 	  						Whether to use the chromedriver on PATH, instead of
               			  	downloading a local copy.
-      --mfa-method {sms,email}
+      --mfa-method {sms,email,soft-token}
                             The MFA method to automate.
+      --mfa-token      The base32 encoded MFA token.
       --imap-account IMAP_ACCOUNT
       --imap-password IMAP_PASSWORD
       --imap-server IMAP_SERVER_HOSTNAME

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
     author='Michael Rooney',
     author_email='mrooney.mintapi@rowk.com',
     url='https://github.com/mrooney/mintapi',
-    install_requires=['future', 'mock', 'requests', 'selenium-requests', 'xmltodict', 'pandas>=1.0', 'selenium'],
+    install_requires=['future', 'mock', 'requests', 'selenium-requests', 'xmltodict', 'pandas>=1.0', 'selenium', 'oathtool'],
     entry_points=dict(
         console_scripts=[
             'mintapi = mintapi.api:main',


### PR DESCRIPTION
Just a quick hack that seems to work.

This adds support for using "authenticator app" option instead of sms/email.  When the user enables this they are given a token that they save and provide as an argument.

I could add keyring support for it as well if desired.