### PR TITLE
Update chromedriver fetch logic to use the latest version from the stable channel (instead of a hard coded version). Related, allow by cli/api the ability to use chromedriver on PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Ensure you have Python 2 or 3 and pip (`easy_install pip`) and then:
 pip install mintapi
 ```
 
-`mintapi` scrapes Mint.com by navigating a Chrome browser (or Chromium) just as a human would. Once logged in, the API allows programatic access to various Mint REST APIs. Selenium/WebDriver is used to accomplish this, and specifically, ChromeDriver under the hood. `mintapi` will download the latest stable release of chromedriver, unless --use_chromedriver_on_path is given. **NOTE: You must have [Chrome](https://www.google.com/chrome/) or [Chromium](https://www.chromium.org/getting-involved/dev-channel/) installed, on the `stable` track, and be up-to-date!**
+`mintapi` scrapes Mint.com by navigating a Chrome browser (or Chromium) just as a human would. Once logged in, the API allows programatic access to various Mint REST APIs. Selenium/WebDriver is used to accomplish this, and specifically, ChromeDriver under the hood. `mintapi` will download the latest stable release of chromedriver, unless --use_chromedriver_on_path is given. **NOTE: You must have [Chrome](https://www.google.com/chrome/) or [Chromium](https://www.chromium.org/getting-involved/dev-channel/) installed, on the `stable` track, and be up-to-date!** If you run into a `SessionNotCreatedException` about "ChromeDriver only supports Chrome version XX", you need to [update Chrome](https://support.google.com/chrome/answer/95414).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Ensure you have Python 2 or 3 and pip (`easy_install pip`) and then:
 pip install mintapi
 ```
 
-`mintapi` scrapes Mint.com by navigating a Chrome browser (or Chromium) just as a human would. Once logged in, the API allows programatic access to various Mint REST APIs. Selenium/WebDriver is used to accomplish this, and specifically, ChromeDriver under the hood. `mintapi` will download the latest stable release of chromedriver, unless --use_chromedriver_on_path is given. **NOTE: You must have [Chrome](https://www.google.com/chrome/) or [Chromium](https://www.chromium.org/getting-involved/dev-channel/) installed, and on the `stable` track.**
+`mintapi` scrapes Mint.com by navigating a Chrome browser (or Chromium) just as a human would. Once logged in, the API allows programatic access to various Mint REST APIs. Selenium/WebDriver is used to accomplish this, and specifically, ChromeDriver under the hood. `mintapi` will download the latest stable release of chromedriver, unless --use_chromedriver_on_path is given. **NOTE: You must have [Chrome](https://www.google.com/chrome/) or [Chromium](https://www.chromium.org/getting-involved/dev-channel/) installed, on the `stable` track, and be up-to-date!**
 
 ## Usage
 
@@ -85,7 +85,7 @@ make calls to retrieve account/budget information.  We recommend using the
 
   # Get net worth
   mint.get_net_worth()
-  
+
   # Get credit score
   mint.get_credit_score()
 
@@ -94,7 +94,7 @@ make calls to retrieve account/budget information.  We recommend using the
 
   # Get investments (holdings and transactions)
   mint.get_invests_json()
-  
+
   # Close session and exit cleanly from selenium/chromedriver
   mint.close()
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,9 @@ Ensure you have Python 2 or 3 and pip (`easy_install pip`) and then:
 
 ```shell
 pip install mintapi
-brew cask install chromedriver # or sudo apt-get install chromium-chromedriver on Ubuntu/Debian
 ```
 
-Note that chromedriver must be version 59+ if you want to use headless mode. If not installing via pip,
-make sure to install the `install_requires` dependencies from setup.py yourself.
+`mintapi` does it scraping by driving an instance of Chrome (or chromium) and navigating, as a human user would, thought the login flows. Once logged in, the API allows programatic access to various Mint REST APIs. Selenium/WebDriver is used to accomplish this, and specifically, ChromeDriver under the hood. `mintapi` will download the latest stable release of chromedriver, unless --use_chromedriver_on_path is given. **NOTE: You must have [Chrome](https://www.google.com/chrome/) or [Chromium](https://www.chromium.org/getting-involved/dev-channel/) installed, and on the `stable` track.**
 
 ## Usage
 
@@ -60,6 +58,8 @@ make calls to retrieve account/budget information.  We recommend using the
     imap_folder='INBOX',  # IMAP folder that receives MFA email
     wait_for_sync=False,  # do not wait for accounts to sync
     wait_for_sync_timeout=300,  # number of seconds to wait for sync
+	use_chromedriver_on_path=False,  # True will use a system provided chromedriver binary that
+	                                 # is on the PATH (instead of downloading the latest version)
   )
 
   # Get basic account information
@@ -149,6 +149,9 @@ Run it as a sub-process from your favorite language; `pip install mintapi` creat
       --keyring             Use OS keyring for storing password information
       --headless            Whether to execute chromedriver with no visible
                             window.
+	  --use-chromedriver-on-path
+	  						Whether to use the chromedriver on PATH, instead of
+              			  	downloading a local copy.
       --mfa-method {sms,email}
                             The MFA method to automate.
       --imap-account IMAP_ACCOUNT
@@ -160,6 +163,7 @@ Run it as a sub-process from your favorite language; `pip install mintapi` creat
       --no_wait_for_sync    Do not wait for accounts to sync
       --wait_for_sync_timeout
                             Number of seconds to wait for sync (default is 300)
+
 
     >>> mintapi --keyring email@example.com
     [

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Ensure you have Python 2 or 3 and pip (`easy_install pip`) and then:
 pip install mintapi
 ```
 
-`mintapi` does it scraping by driving an instance of Chrome (or chromium) and navigating, as a human user would, thought the login flows. Once logged in, the API allows programatic access to various Mint REST APIs. Selenium/WebDriver is used to accomplish this, and specifically, ChromeDriver under the hood. `mintapi` will download the latest stable release of chromedriver, unless --use_chromedriver_on_path is given. **NOTE: You must have [Chrome](https://www.google.com/chrome/) or [Chromium](https://www.chromium.org/getting-involved/dev-channel/) installed, and on the `stable` track.**
+`mintapi` scrapes Mint.com by navigating a Chrome browser (or Chromium) just as a human would. Once logged in, the API allows programatic access to various Mint REST APIs. Selenium/WebDriver is used to accomplish this, and specifically, ChromeDriver under the hood. `mintapi` will download the latest stable release of chromedriver, unless --use_chromedriver_on_path is given. **NOTE: You must have [Chrome](https://www.google.com/chrome/) or [Chromium](https://www.chromium.org/getting-involved/dev-channel/) installed, and on the `stable` track.**
 
 ## Usage
 

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -16,6 +16,7 @@ import imaplib
 import email
 import email.header
 import sys  # DEBUG
+import warnings
 
 try:
     from StringIO import StringIO  # Python 2
@@ -64,7 +65,13 @@ def reverse_credit_amount(row):
     return amount if row['isDebit'] else -amount
 
 
-def get_email_code(imap_account, imap_password, imap_server, imap_folder, delete=True):
+def get_email_code(imap_account, imap_password, imap_server, imap_folder, debug=False, delete=True):
+    if debug:
+        warnings.warn(
+            "debug param to get_email_code() is deprecated and will be "
+            "removed soon; use: logging.getLogger('mintapi')"
+            ".setLevel(logging.DEBUG) to show DEBUG log messages.",
+            DeprecationWarning)
     code = None
     imap_client = imaplib.IMAP4_SSL(imap_server)
 

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -175,7 +175,7 @@ CHROME_ZIP_TYPES = {
 
 
 def get_latest_chrome_driver_url(platform):
-    # Download the latest chrome driver from the stable channel.
+    """Returns the url for the latest stable chromedriver for platform."""
     latest_url = CHROME_DRIVER_BASE_URL + 'LATEST_RELEASE'
     latest_request = requests.get(latest_url)
 

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -413,7 +413,8 @@ class Mint(object):
                                      imap_server=imap_server,
                                      imap_folder=imap_folder,
                                      wait_for_sync=wait_for_sync,
-                                     wait_for_sync_timeout=wait_for_sync_timeout)
+                                     wait_for_sync_timeout=wait_for_sync_timeout,
+                                     use_chromedriver_on_path=use_chromedriver_on_path)
 
     @classmethod
     def create(cls, email, password, **opts):

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -174,6 +174,21 @@ CHROME_ZIP_TYPES = {
 }
 
 
+def get_latest_chrome_driver_url(platform):
+    # Download the latest chrome driver from the stable channel.
+    latest_url = CHROME_DRIVER_BASE_URL + 'LATEST_RELEASE'
+    latest_request = requests.get(latest_url)
+
+    if latest_request.status_code != 200:
+        raise RuntimeError(
+            'Error finding the latest chromedriver at {}, status = {}'.format(
+                latest_url, latest_request.status_code))
+
+    latest_version = latest_request.text
+    return CHROME_DRIVER_BASE_URL + CHROME_DRIVER_DOWNLOAD_PATH.format(
+        version=latest_version, arch=CHROME_ZIP_TYPES.get(platform))
+
+
 def get_web_driver(email, password, headless=False, mfa_method=None,
                    mfa_input_callback=None, wait_for_sync=True,
                    wait_for_sync_timeout=5 * 60,
@@ -184,24 +199,12 @@ def get_web_driver(email, password, headless=False, mfa_method=None,
                       "is unlikely to lead to a successful login. Defaulting --mfa-method=sms")
         mfa_method = "sms"
 
-    zip_type = CHROME_ZIP_TYPES.get(_platform)
     executable_path = os.getcwd() + os.path.sep + 'chromedriver'
     if _platform in ['win32', 'win64']:
         executable_path += '.exe'
 
     if not os.path.exists(executable_path):
-        # Download the latest chrome driver from the stable channel.
-        latest_url = CHROME_DRIVER_BASE_URL + 'LATEST_RELEASE'
-        latest_request = requests.get(latest_url)
-
-        if latest_request.status_code != 200:
-            raise RuntimeError(
-                'Error finding the latest chromedriver at {}, status = {}'.format(
-                    latest_url, latest_request.status_code))
-
-        latest_version = latest_request.text
-        zip_file_url = CHROME_DRIVER_BASE_URL + CHROME_DRIVER_DOWNLOAD_PATH.format(
-            version=latest_version, arch=zip_type)
+        zip_file_url = get_latest_chrome_driver_url(_platform)
         request = requests.get(zip_file_url)
 
         if request.status_code != 200:

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -213,11 +213,11 @@ def get_stable_chrome_driver():
         if major_version == latest_major_version:
             return local_executable_path
         logger.info('Removing old version {} of Chromedriver'.format(
-              major_version))
+            major_version))
         os.remove(local_executable_path)
 
     logger.info('Downloading version {} of Chromedriver'.format(
-          latest_chrome_driver_version))
+        latest_chrome_driver_version))
     zip_file_url = get_chrome_driver_url(
         latest_chrome_driver_version, _platform)
     request = requests.get(zip_file_url)

--- a/mintapi/tests.py
+++ b/mintapi/tests.py
@@ -46,9 +46,10 @@ class MintApiTests(unittest.TestCase):
         mintapi.print_accounts(accounts)
 
     def test_chrome_driver_links(self):
+        latest_version = mintapi.api.get_latest_chrome_driver_version()
         for platform in mintapi.api.CHROME_ZIP_TYPES:
             request = requests.get(
-                mintapi.api.get_latest_chrome_driver_url(platform))
+                mintapi.api.get_chrome_driver_url(latest_version, platform))
             self.assertEqual(request.status_code, 200)
 
     def test_parse_float(self):

--- a/mintapi/tests.py
+++ b/mintapi/tests.py
@@ -47,9 +47,8 @@ class MintApiTests(unittest.TestCase):
 
     def test_chrome_driver_links(self):
         for platform in mintapi.api.CHROME_ZIP_TYPES:
-            zip_type = mintapi.api.CHROME_ZIP_TYPES.get(platform)
-            zip_file_url = mintapi.api.CHROME_DRIVER_BASE_URL % (mintapi.api.CHROME_DRIVER_VERSION, zip_type)
-            request = requests.get(zip_file_url)
+            request = requests.get(
+                mintapi.api.get_latest_chrome_driver_url(platform))
             self.assertEqual(request.status_code, 200)
 
     def test_parse_float(self):


### PR DESCRIPTION
See #201 for context. Turns out that using the latest and greatest (major release 81) doesn't work with older versions. So instead of using something from beta channel, most users will stick to something on stable. If a user has an out of date chrome browser, they may run into issues, and should update their browser before using any fintech websites anyway.

I looked into the various chromedriver pypi packages, and it seems that all the ones that either bundle the binary in the package, or download chomedriver and install on the path at module install time are all grabbing the beta latest, not the stable latest.