### PR TITLE
Remove deprecated call to pd.np.nan

### DIFF
--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -705,7 +705,7 @@ class Mint(object):
         df = pd.read_csv(s, parse_dates=['Date'])
         df.columns = [c.lower().replace(' ', '_') for c in df.columns]
         df.category = (df.category.str.lower()
-                       .replace('uncategorized', pd.np.nan))
+                       .replace('uncategorized', pd.NA))
         return df
 
     def populate_extended_account_detail(self, accounts):  # {{{


### PR DESCRIPTION
`pd.np.nan` is deprecated. You could import `np` and then use `np.nan` (which I'm fine doing, if you prefer), but pandas has added `pd.NA` which plays nicely with dataframes. See
https://stackoverflow.com/questions/60115806/pd-na-vs-np-nan-for-pandas
and
https://pandas.pydata.org/pandas-docs/stable/user_guide/missing_data.html#experimental-na-scalar-to-denote-missing-values

Original warning:
```
/lib/python3.7/site-packages/mintapi/api.py:692: FutureWarning: The pandas.np module is deprecated and will be removed from pandas in a future version. Import numpy directly instead
  .replace('uncategorized', pd.np.nan))
```