### PR TITLE
A fix and an enhancement to budgets

### DIFF
--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -940,7 +940,7 @@ class Mint(object):
                     str(max(map(int, response['data']['income'].keys())))
                 ]['bu'],
                 'spend': response['data']['spending'][
-                    str(max(map(int, response['data']['income'].keys())))
+                    str(max(map(int, response['data']['spending'].keys())))
                 ]['bu']
             }
 

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -928,10 +928,9 @@ class Mint(object):
             for month in budgets.keys():
                 for direction in budgets[month]:
                     for budget in budgets[month][direction]:
-                        budget['cat'] = self.get_category_from_id(
-                            budget['cat'],
-                            categories
-                        )
+                        category = self.get_category_from_id(budget['cat'], categories)
+                        budget['cat'] = category['name']
+                        budget['parent'] = category['parent']['name']
 
         else:
             # Make the skeleton return structure
@@ -947,10 +946,9 @@ class Mint(object):
             # Fill in the return structure
             for direction in budgets.keys():
                 for budget in budgets[direction]:
-                    budget['cat'] = self.get_category_from_id(
-                        budget['cat'],
-                        categories
-                    )
+                    category = self.get_category_from_id(budget['cat'], categories)
+                    budget['cat'] = category['name']
+                    budget['parent'] = category['parent']['name']
 
         return budgets
 
@@ -960,12 +958,12 @@ class Mint(object):
 
         for i in categories:
             if categories[i]['id'] == cid:
-                return categories[i]['name']
+                return categories[i]
 
             if 'children' in categories[i]:
                 for j in categories[i]['children']:
                     if categories[i][j]['id'] == cid:
-                        return categories[i][j]['name']
+                        return categories[i][j]
 
         return 'Unknown'
 

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -928,7 +928,7 @@ class Mint(object):
             for month in budgets.keys():
                 for direction in budgets[month]:
                     for budget in budgets[month][direction]:
-                        category = self.get_category_from_id(budget['cat'], categories)
+                        category = self.get_category_object_from_id(budget['cat'], categories)
                         budget['cat'] = category['name']
                         budget['parent'] = category['parent']['name']
 
@@ -946,15 +946,19 @@ class Mint(object):
             # Fill in the return structure
             for direction in budgets.keys():
                 for budget in budgets[direction]:
-                    category = self.get_category_from_id(budget['cat'], categories)
+                    category = self.get_category_object_from_id(budget['cat'], categories)
                     budget['cat'] = category['name']
                     budget['parent'] = category['parent']['name']
 
         return budgets
 
     def get_category_from_id(self, cid, categories):
+        category = self.get_category_object_from_id(cid, categories)
+        return category['name']
+
+    def get_category_object_from_id(self, cid, categories):
         if cid == 0:
-            return 'Uncategorized'
+            return {'parent' : 'Uncategorized', 'name' : 'Uncategorized'}
 
         for i in categories:
             if categories[i]['id'] == cid:
@@ -965,7 +969,7 @@ class Mint(object):
                     if categories[i][j]['id'] == cid:
                         return categories[i][j]
 
-        return 'Unknown'
+        return {'parent' : 'Unknown', 'name' : 'Unknown'}
 
     def initiate_account_refresh(self):
         self.post(


### PR DESCRIPTION
This makes two changes
* In `get_budgets()`, when not including history, uses the correct key for finding the most recent spending data - this may have only been a semantic fix, though, because (anecdotally speaking) I don't think I was seeing any actual issues that this would have caused previously
* Adds a `parent` field to budgets
  * Does so by changing `get_category_from_id()` to return an object instead of a string - are there any concerns here in terms of downstream breakage?  If so I can keep the API surface the same and add a separate function that returns the object for internal use.
  * I didn't do a `try`/`except` block or LBYL check when accessing the `parent` field on returned categories, because (again, anecdotally speaking) I didn't see any issues with my specific set of returned data.  I can always add them, though, if there's a concern.

Cheers :)