### PR TITLE
Fix chromedriver RE logic to prevent issue with greedy matching. Also fixes win10 error.

### DIFF
--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -176,8 +176,8 @@ CHROME_ZIP_TYPES = {
     'win64': 'win32'
 }
 version_pattern = re.compile(
-    ".*(?P<version>(?P<major>\\d+)\\.(?P<minor>\\d+)\\."
-    "(?P<build>\\d+)\\.(?P<patch>\\d+)).*")
+    "(?P<version>(?P<major>\\d+)\\.(?P<minor>\\d+)\\."
+    "(?P<build>\\d+)\\.(?P<patch>\\d+))")
 
 
 def get_chrome_driver_url(version, arch):
@@ -187,11 +187,18 @@ def get_chrome_driver_url(version, arch):
 
 def get_chrome_driver_major_version_from_executable(local_executable_path):
     # Note; --version works on windows as well.
-    version = subprocess.check_output([local_executable_path, '--version'])
-    version_match = version_pattern.match(version.decode())
-    if not version_match:
-        return None
-    return version_match.groupdict()['major']
+    # check_output fails if running from a thread without a console on win10.
+    # To protect against this use explicit pipes for STDIN/STDERR.
+    # See: https://github.com/pyinstaller/pyinstaller/issues/3392
+    with open(os.devnull, 'wb') as DEVNULL:
+        version = subprocess.check_output(
+            [local_executable_path, '--version'],
+            stderr=DEVNULL,
+            stdin=DEVNULL)
+        version_match = version_pattern.search(version.decode())
+        if not version_match:
+            return None
+        return version_match.groupdict()['major']
 
 
 def get_latest_chrome_driver_version():


### PR DESCRIPTION
The leading wildcards in the version pattern with `.*` was causing the leading digit on the major version to be removed from the match. The logic around subprocess is modified to support running from a detached context, with no explicit stdin/out. This happens readily when running on win10 with a PyInstaller binary.