### PR TITLE
Change method for getting current year for odate

### DIFF
--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -51,7 +51,7 @@ def assert_pd():
 
 
 def json_date_to_datetime(dateraw):
-    cy = datetime.isocalendar(date.today())[0]
+    cy = date.today().year
     try:
         newdate = datetime.strptime(dateraw + str(cy), '%b %d%Y')
     except ValueError:


### PR DESCRIPTION
Mint.com returns transactions from the current year as a string without the year (i.e. 'Jan 1').  The function json_date_to_datetime() attempts to resolve this shortcoming by appending the current year.  In certain scenarios at the start of a year the isocalendar function may return the previous year.  Updating to use date.today().year.