### PR TITLE
fix: Fix for 'string indices must be integers'

### DIFF
--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -1023,7 +1023,11 @@ class Mint(object):
                 for budget in budgets[direction]:
                     category = self.get_category_object_from_id(budget['cat'], categories)
                     budget['cat'] = category['name']
-                    budget['parent'] = category['parent']['name']
+                    # Uncategorized budget's parent is a string: 'Uncategorized'
+                    if isinstance(category['parent'], dict):
+                        budget['parent'] = category['parent']['name']
+                    else:
+                        budget['parent'] = category['parent']
 
         return budgets
 


### PR DESCRIPTION
The 'Uncategorized' budget's parent is a string not a dict.
Probably only affects those who put a specific limit on uncategorized.

Refs #253