### PR TITLE
alternate Select email address for MFA authentication

### DIFF
--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -380,7 +380,12 @@ def _sign_in(email, password, driver, mfa_method=None, mfa_token=None,
                     try:
                         mfa_email_select = driver.find_element_by_id("ius-mfa-email-otp-card-challenge")
                         mfa_email_select.click()
-                    except NoSuchElementException:
+                    except (NoSuchElementException, ElementNotInteractableException):
+                        pass  # no option to select email address
+                    try:
+                        mfa_email_select = driver.find_element_by_id("ius-sublabel-mfa-email-otp")
+                        mfa_email_select.click()
+                    except (NoSuchElementException, ElementNotInteractableException):
                         pass  # no option to select email address
 
                 try:

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -381,6 +381,7 @@ def _sign_in(email, password, driver, mfa_method=None, mfa_token=None,
                         try:
                             mfa_email_select = driver.find_element_by_id(element_id)
                             mfa_email_select.click()
+                            break
                         except (NoSuchElementException, ElementNotInteractableException):
                             pass  # no option to select email address
 

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -377,16 +377,12 @@ def _sign_in(email, password, driver, mfa_method=None, mfa_token=None,
                     pass  # no option to select mfa option
 
                 if mfa_method == 'email' and imap_account:
-                    try:
-                        mfa_email_select = driver.find_element_by_id("ius-mfa-email-otp-card-challenge")
-                        mfa_email_select.click()
-                    except (NoSuchElementException, ElementNotInteractableException):
-                        pass  # no option to select email address
-                    try:
-                        mfa_email_select = driver.find_element_by_id("ius-sublabel-mfa-email-otp")
-                        mfa_email_select.click()
-                    except (NoSuchElementException, ElementNotInteractableException):
-                        pass  # no option to select email address
+                    for element_id in ["ius-mfa-email-otp-card-challenge", "ius-sublabel-mfa-email-otp"]:
+                        try:
+                            mfa_email_select = driver.find_element_by_id(element_id)
+                            mfa_email_select.click()
+                        except (NoSuchElementException, ElementNotInteractableException):
+                            pass  # no option to select email address
 
                 try:
                     mfa_code_input = driver.find_element_by_id("ius-mfa-confirm-code")


### PR DESCRIPTION
I'm now getting a different page that wants you to click your 2FA email address.  I don't know whether this page replaces the older one or is just an alternative.  This pull request will work for either the older page or the current one.