### PR TITLE
[FEATURE] Specify Chrome Release

### DIFF
--- a/mintapi/signIn.py
+++ b/mintapi/signIn.py
@@ -184,7 +184,7 @@ def get_email_code(imap_account, imap_password, imap_server, imap_folder, delete
 
 CHROME_DRIVER_BASE_URL = "https://chromedriver.storage.googleapis.com/"
 CHROME_DRIVER_DOWNLOAD_PATH = "{version}/chromedriver_{arch}.zip"
-CHROME_DRIVER_LATEST_RELEASE = "LATEST_RELEASE"
+CHROME_DRIVER_LATEST_RELEASE = "LATEST_RELEASE_105.0.5195"
 CHROME_ZIP_TYPES = {
     "linux": "linux64",
     "linux2": "linux64",


### PR DESCRIPTION
This PR adds a _hard-coded_ chrome release which fixes #553 and #546 for me.

REQUEST: I need help making this an option, not a hard-coded reference to a specfic Chrome release. I'm not sure where to make changes in the code for this and keep things clean/efficient. Would love some help modifying the PR so users can specify a Chrome release in the `mintapi.Mint()` command.