### PR TITLE
Add new chromium flag for headless

### DIFF
--- a/mintapi/signIn.py
+++ b/mintapi/signIn.py
@@ -300,6 +300,7 @@ def _create_web_driver_at_mint_com(
     chrome_options = ChromeOptions()
     if headless:
         chrome_options.add_argument("headless")
+        chrome_options.add_argument("headless=new")
         chrome_options.add_argument("no-sandbox")
         chrome_options.add_argument("disable-dev-shm-usage")
         chrome_options.add_argument("disable-gpu")


### PR DESCRIPTION
Add the new headless=new flag for headless browsing in chromium.

NOTE: Took the approach of just adding the flag, not backtested with old chromium versions (hopefully old versions ignore bogus flags)