### PR TITLE
feat - add new endpoint for tags

### DIFF
--- a/mintapi/endpoints.py
+++ b/mintapi/endpoints.py
@@ -193,6 +193,22 @@ class MintEndpoints(object, metaclass=ABCMeta):
             **kwargs,
         )
 
+    def _get_tag_data(self, **kwargs):
+        api_url = MINT_ROOT_URL
+        api_section = "/pfm"
+        uri_path = "/v1/tags"
+        metadata_key = "metaData"
+        data_key = "Tag"
+
+        return self.get(
+            api_url=api_url,
+            api_section=api_section,
+            uri_path=uri_path,
+            data_key=data_key,
+            metadata_key=metadata_key,
+            **kwargs,
+        )
+
     def _get_credit_accounts(self, **kwargs):
         api_url = MINT_CREDIT_URL
         api_section = ""
@@ -394,6 +410,26 @@ class MintEndpoints(object, metaclass=ABCMeta):
         }
         params = {k: v for k, v in params.items() if v is not None}
         return self._get_category_data(params=params, **kwargs)
+
+    def get_tag_data(self, limit: int = 1000, **kwargs):
+        """
+        _summary_
+
+        Parameters
+        ----------
+        limit : int, optional
+            _description_, by default 1000
+
+        Returns
+        -------
+        _type_
+            _description_
+        """
+        params = {
+            "limit": limit,
+        }
+        params = {k: v for k, v in params.items() if v is not None}
+        return self._get_tag_data(params=params, **kwargs)
 
     def get_credit_accounts(self, **kwargs):
         """

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -263,6 +263,30 @@ class EndpointRequestTests(unittest.TestCase):
         mintapi.endpoints.MintEndpoints, "__abstractmethods__", new_callable=set
     )
     @patch.object(mintapi.endpoints.MintEndpoints, "request")
+    def test_tag_endpoint(self, mock_request, _):
+        """
+        Tests params are correctly passed to the request method
+        """
+        # Future TODO: mock full api response
+        mock_request.return_value = None
+        endpoints = MintEndpoints()
+        data = endpoints._get_tag_data()
+        self.assertIsNone(data)
+
+        # assert pagination call
+        mock_request.assert_called_once_with(
+            data_key="Tag",
+            metadata_key="metaData",
+            api_section="/pfm",
+            api_url="https://mint.intuit.com",
+            method="GET",
+            uri_path="/v1/tags",
+        )
+
+    @patch.object(
+        mintapi.endpoints.MintEndpoints, "__abstractmethods__", new_callable=set
+    )
+    @patch.object(mintapi.endpoints.MintEndpoints, "request")
     def test_credit_account_endpoint(self, mock_request, _):
         """
         Tests params are correctly passed to the request method


### PR DESCRIPTION
This PR adds a new endpoint for retrieving the tags used to mark transactions.