### PR TITLE
feat - add new endpoint for getting rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,12 @@ make calls to retrieve account/budget information.  We recommend using the
 
   # Get investments (holdings and transactions)
   mint.get_investment_data()
+  
+  # Get tags
+  mint.get_tag_data()
+  
+  # Get rules for assigning category and description
+  mint.get_rule_data()
 
   # Close session and exit cleanly from selenium/chromedriver
   mint.close()

--- a/mintapi/endpoints.py
+++ b/mintapi/endpoints.py
@@ -193,6 +193,22 @@ class MintEndpoints(object, metaclass=ABCMeta):
             **kwargs,
         )
 
+    def _get_tag_data(self, **kwargs):
+        api_url = MINT_ROOT_URL
+        api_section = "/pfm"
+        uri_path = "/v1/tags"
+        metadata_key = "metaData"
+        data_key = "Tag"
+
+        return self.get(
+            api_url=api_url,
+            api_section=api_section,
+            uri_path=uri_path,
+            data_key=data_key,
+            metadata_key=metadata_key,
+            **kwargs,
+        )
+
     def _get_credit_accounts(self, **kwargs):
         api_url = MINT_CREDIT_URL
         api_section = ""
@@ -394,6 +410,26 @@ class MintEndpoints(object, metaclass=ABCMeta):
         }
         params = {k: v for k, v in params.items() if v is not None}
         return self._get_category_data(params=params, **kwargs)
+
+    def get_tag_data(self, limit: int = 1000, **kwargs):
+        """
+        _summary_
+
+        Parameters
+        ----------
+        limit : int, optional
+            _description_, by default 1000
+
+        Returns
+        -------
+        _type_
+            _description_
+        """
+        params = {
+            "limit": limit,
+        }
+        params = {k: v for k, v in params.items() if v is not None}
+        return self._get_tag_data(params=params, **kwargs)
 
     def get_credit_accounts(self, **kwargs):
         """

--- a/mintapi/endpoints.py
+++ b/mintapi/endpoints.py
@@ -209,6 +209,22 @@ class MintEndpoints(object, metaclass=ABCMeta):
             **kwargs,
         )
 
+    def _get_rules_data(self, **kwargs):
+        api_url = MINT_ROOT_URL
+        api_section = "/pfm"
+        uri_path = "/v1/transaction-rules"
+        metadata_key = "metaData"
+        data_key = "TransactionRules"
+
+        return self.get(
+            api_url=api_url,
+            api_section=api_section,
+            uri_path=uri_path,
+            data_key=data_key,
+            metadata_key=metadata_key,
+            **kwargs,
+        )
+
     def _get_credit_accounts(self, **kwargs):
         api_url = MINT_CREDIT_URL
         api_section = ""
@@ -430,6 +446,26 @@ class MintEndpoints(object, metaclass=ABCMeta):
         }
         params = {k: v for k, v in params.items() if v is not None}
         return self._get_tag_data(params=params, **kwargs)
+
+    def get_rule_data(self, limit: int = 1000, **kwargs):
+        """
+        _summary_
+
+        Parameters
+        ----------
+        limit : int, optional
+            _description_, by default 1000
+
+        Returns
+        -------
+        _type_
+            _description_
+        """
+        params = {
+            "limit": limit,
+        }
+        params = {k: v for k, v in params.items() if v is not None}
+        return self._get_rules_data(params=params, **kwargs)
 
     def get_credit_accounts(self, **kwargs):
         """

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -287,6 +287,30 @@ class EndpointRequestTests(unittest.TestCase):
         mintapi.endpoints.MintEndpoints, "__abstractmethods__", new_callable=set
     )
     @patch.object(mintapi.endpoints.MintEndpoints, "request")
+    def test_rule_endpoint(self, mock_request, _):
+        """
+        Tests params are correctly passed to the request method
+        """
+        # Future TODO: mock full api response
+        mock_request.return_value = None
+        endpoints = MintEndpoints()
+        data = endpoints._get_rules_data()
+        self.assertIsNone(data)
+
+        # assert pagination call
+        mock_request.assert_called_once_with(
+            data_key="TransactionRules",
+            metadata_key="metaData",
+            api_section="/pfm",
+            api_url="https://mint.intuit.com",
+            method="GET",
+            uri_path="/v1/transaction-rules",
+        )
+
+    @patch.object(
+        mintapi.endpoints.MintEndpoints, "__abstractmethods__", new_callable=set
+    )
+    @patch.object(mintapi.endpoints.MintEndpoints, "request")
     def test_credit_account_endpoint(self, mock_request, _):
         """
         Tests params are correctly passed to the request method

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -263,6 +263,30 @@ class EndpointRequestTests(unittest.TestCase):
         mintapi.endpoints.MintEndpoints, "__abstractmethods__", new_callable=set
     )
     @patch.object(mintapi.endpoints.MintEndpoints, "request")
+    def test_tag_endpoint(self, mock_request, _):
+        """
+        Tests params are correctly passed to the request method
+        """
+        # Future TODO: mock full api response
+        mock_request.return_value = None
+        endpoints = MintEndpoints()
+        data = endpoints._get_tag_data()
+        self.assertIsNone(data)
+
+        # assert pagination call
+        mock_request.assert_called_once_with(
+            data_key="Tag",
+            metadata_key="metaData",
+            api_section="/pfm",
+            api_url="https://mint.intuit.com",
+            method="GET",
+            uri_path="/v1/tags",
+        )
+
+    @patch.object(
+        mintapi.endpoints.MintEndpoints, "__abstractmethods__", new_callable=set
+    )
+    @patch.object(mintapi.endpoints.MintEndpoints, "request")
     def test_credit_account_endpoint(self, mock_request, _):
         """
         Tests params are correctly passed to the request method


### PR DESCRIPTION
This PR adds an endpoint for getting the rules logic for assigning the category and description for transactions.