### PR TITLE
fix: cli bills calling wrong endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ Run it as a sub-process from your favorite language; `pip install mintapi` creat
                             MFA prompts. Defaults to $HOME/.mintapi/session. Set to None to use a temporary
                             profile.
       --beta                Use the beta version of Mint
+      --bills               Retrieve bills information
       --budgets             Retrieve budget information for current month
       --budget_hist         Retrieve historical budget information (past 12 months)
       --categories          Retrieve your configured Mint categories

--- a/mintapi/cli.py
+++ b/mintapi/cli.py
@@ -544,7 +544,7 @@ def main():
         output_data(options, data, ACCOUNT_KEY, attention_msg)
 
     if options.bills:
-        data = mint.get_bills()
+        data = mint.get_bills_data()
         output_data(options, data, BILL_KEY, attention_msg)
 
     if options.budgets:


### PR DESCRIPTION
### Summary
While using the CLI version, I noticed that the bills option is not mentioned in the README.md and that the pathway was broken. I added it to the README.md and fixed the function  call.

### Testing
I tested it locally by running the CLI with the bills argument and received data.